### PR TITLE
Adapt to use pyIcePAP API 2.0

### DIFF
--- a/icepapCMS/lib_icepapcms/__init__.py
+++ b/icepapCMS/lib_icepapcms/__init__.py
@@ -5,5 +5,4 @@ from conflict import Conflict
 from configmanager import ConfigManager
 from timer import Timer
 from icepapcontroller import *
-from pyIcePAP import *
 from IPy import *

--- a/icepapCMS/lib_icepapcms/icepapcontroller.py
+++ b/icepapCMS/lib_icepapcms/icepapcontroller.py
@@ -63,6 +63,7 @@ class IcepapController(Singleton):
         # log_folder = None
         # if self.debug:
         #     log_folder = self.log_folder
+
         if not self.host_in_same_subnet(icepap_name):
             MessageDialogs.showInformationMessage(None, "Host connection",
                                                   "It is not allowed to "
@@ -72,6 +73,10 @@ class IcepapController(Singleton):
         else:
             try:
                 # TODO: Configure logging log_path=log_folder
+                if self.debug:
+                    import logging
+                    logging.basicConfig(level=logging.DEBUG)
+
                 self.iPaps[icepap_name] = EthIcePAPController(host, port)
                 return True
             except Exception:

--- a/icepapCMS/lib_icepapcms/icepapcontroller.py
+++ b/icepapCMS/lib_icepapcms/icepapcontroller.py
@@ -547,12 +547,12 @@ class IcepapController(Singleton):
             return False
         return True
 
+    def isExpertFlagSet(self, icepap_name, driver_addr):
+        axis = self.iPaps[icepap_name][driver_addr]
         try:
-            return self.iPaps[icepap_name].checkDriver(driver_addr)
+            return axis.get_cfg('EXPERT')['EXPERT']
         except Exception:
-            print "Unexpected error:", sys.exc_info()[0]
-            return -1
-
+            return 'NO'
 
     def _parseDriverTemplateFile(self):
         self.config_parameters = []

--- a/icepapCMS/lib_icepapcms/icepapcontroller.py
+++ b/icepapCMS/lib_icepapcms/icepapcontroller.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
-
+# !/usr/bin/env python
 # ------------------------------------------------------------------------------
-# This file is part of icepapCMS (https://github.com/ALBA-Synchrotron/icepapcms)
+# This file is part of IcepapCMS
+#      https://github.com/ALBA-Synchrotron/icepapcms
 #
 # Copyright 2008-2018 CELLS / ALBA Synchrotron, Bellaterra, Spain
 #
@@ -11,33 +11,31 @@
 # ------------------------------------------------------------------------------
 
 
-#from pyIcePAP import EthIcePAP, IcePAPException, IcePAP, SerialIcePAP
-from pyIcePAP import *
+from pyIcePAP import IcepapMode, IcePAPException, IcePAP, EthIcePAP, \
+    SerialIcePAP, IcepapStatus
 from xml.dom import minidom, Node
 import os
 import sys
 from singleton import Singleton
-import struct
-import time, datetime
-import array
-from icepapdrivercfg import IcepapDriverCfg, CfgParameter
+import time
+import datetime
+from icepapdrivercfg import IcepapDriverCfg
 import icepapdriver
-from conflict import Conflict
 from configmanager import ConfigManager
 from ..ui_icepapcms.messagedialogs import MessageDialogs
 from PyQt4 import QtCore
-from PyQt4 import QtGui
 from PyQt4 import Qt
 import re
 import socket
 from IPy import IP
 
+
 class IcepapController(Singleton):
-    
+
     def __init__(self):
         pass
-    
-    def init(self, *args):        
+
+    def init(self, *args):
         self.iPaps = {}
         pathname = os.path.dirname(sys.argv[0])
         path = os.path.abspath(pathname)
@@ -48,59 +46,63 @@ class IcepapController(Singleton):
         self._config = ConfigManager()
         self.icepap_cfginfos = {}
         self.icepap_cfgorder = {}
-        self.programming_ipap = None        
+        self.programming_ipap = None
         try:
-            self.debug = self._config.config[self._config.icepap]["debug_enabled"] == str(True)
-            self.log_folder = self._config.config[self._config.icepap]["log_folder"]
+            ipap = self._config.icepap
+            debug_set = self._config.config[ipap]["debug_enabled"]
+            self.debug = debug_set == str(True)
+            self.log_folder = self._config.config[ipap]["log_folder"]
             if not os.path.exists(self.log_folder):
-                os.mkdir(self.log_folder)            
-        except:
+                os.mkdir(self.log_folder)
+        except Exception:
             print "icepapcontroller_init():", sys.exc_info()
             pass
-       
+
     def reset(self):
         self.closeAllConnections()
         self.iPaps = {}
-        
+
     def openConnection(self, icepap_name, host, port):
         log_folder = None
         if self.debug:
             log_folder = self.log_folder
         if not self.host_in_same_subnet(icepap_name):
-            MessageDialogs.showInformationMessage(None,"Host connection","It is not allowed to connect to %s. (Check subnet)"%host)
+            MessageDialogs.showInformationMessage(None, "Host connection",
+                                                  "It is not allowed to "
+                                                  "connect to %s. (Check "
+                                                  "subnet)" % host)
             return False
         else:
             try:
-                self.iPaps[icepap_name] = EthIcePAP(host, port, log_path = log_folder)
+                self.iPaps[icepap_name] = EthIcePAP(host, port,
+                                                    log_path=log_folder)
                 self.iPaps[icepap_name].connect()
                 return True
-            except Exception,e:
-                #print "icepapcontroller: Some exception opening connection.",e
+            except Exception:
                 return False
-        
+
     def closeConnection(self, icepap_name):
-        if self.iPaps.has_key(icepap_name):
+        if icepap_name in self.iPaps:
             self.iPaps[icepap_name].disconnect()
             del self.iPaps[icepap_name]
-    
+
     def closeAllConnections(self):
         for iPap in self.iPaps.values():
             try:
                 iPap.disconnect()
-            except:
+            except Exception:
                 pass
         self.iPaps = {}
-        
-        
-    def scanIcepapSystem(self, icepap_name, compare = False):
-        """ 
-            Get the status of the icepap system, the drivers present, and its
-            configuration.
+
+    def scanIcepapSystem(self, icepap_name, compare=False):
+        """
+        Get the status of the icepap system, the drivers present, and its
+        configuration.
         """
         driver_name = icepap_name
         if compare:
             driver_name = "compare"
-        
+
         driver_list = {}
         self.icepap_cfginfos[icepap_name] = {}
         self.icepap_cfgorder[icepap_name] = {}
@@ -114,41 +116,48 @@ class IcepapController(Singleton):
                 driver.addConfiguration(driver_cfg)
 
                 # CFGINFO IS ALSO SPECIFIC FOR EACH DRIVER
-                # To improve speed, this is true but instead of 'each driver', better each version
-                driver_version = driver_cfg.getParameter(unicode('VER'),True)
-                if not cfginfos_version_dict.has_key(driver_version):
-                    cfginfo_dict,order_list = self.getDriverCfgInfoDictAndList(icepap_name,addr)
-                    cfginfos_version_dict[driver_version] = (cfginfo_dict, order_list)
+                # To improve speed, this is true but instead of 'each driver',
+                # better each version
+                driver_version = driver_cfg.getParameter(unicode('VER'), True)
+                if driver_version not in cfginfos_version_dict:
+                    cfginfo_dict, order_list = \
+                        self.getDriverCfgInfoDictAndList(icepap_name, addr)
+                    cfginfos_version_dict[driver_version] = (cfginfo_dict,
+                                                             order_list)
 
                 # GET CFGINFO FROM CACHED DICT INSTEAD OF QUERYING EACH TIME
-                #cfginfo_dict,order_list = self.getDriverCfgInfoDictAndList(icepap_name,addr)
-                cfginfo_dict,order_list = cfginfos_version_dict[driver_version]
-                
-                self.icepap_cfginfos[icepap_name][addr] = cfginfo_dict    
+                # cfginfo_dict,order_list = \
+                #     self.getDriverCfgInfoDictAndList(icepap_name,addr)
+                cfginfo_dict, order_list = \
+                    cfginfos_version_dict[driver_version]
+
+                self.icepap_cfginfos[icepap_name][addr] = cfginfo_dict
                 self.icepap_cfgorder[icepap_name][addr] = order_list
 
-                driver.setName(driver_cfg.getParameter(unicode("IPAPNAME"),True))
+                driver.setName(driver_cfg.getParameter(
+                    unicode("IPAPNAME"), True))
                 driver.setMode(self.iPaps[icepap_name].getMode(addr))
                 driver_list[addr] = driver
-                            
-        except Exception,e:
+
+        except Exception as e:
             self.closeConnection(icepap_name)
-            print 'exception:',e
+            print 'exception:', e
             raise
         return driver_list
-    
+
     def getDriverConfiguration(self, icepap_name, driver_addr):
         """
             Returns a IcepaDriverCfg object of the attributes predefined in
             driverparameters.xml
         """
-        
-        """ TO-DO STORM review"""   
+
+        """ TO-DO STORM review"""
         driver_cfg = IcepapDriverCfg(unicode(datetime.datetime.now()))
         driver_cfg.setSignature(self.iPaps[icepap_name].getConfig(driver_addr))
-        #ver = self.iPaps[icepap_name].getVersionDsp(driver_addr)
-        # THE VERSION NUMBER TO BE SHOWN IS THE DRIVER'S VERSION INSTEAD OF THE DSP'S ONE.
-        ver = self.iPaps[icepap_name].getVersion(driver_addr,"DRIVER")
+        # ver = self.iPaps[icepap_name].getVersionDsp(driver_addr)
+        # THE VERSION NUMBER TO BE SHOWN IS THE DRIVER'S VERSION INSTEAD OF
+        # THE DSP'S ONE.
+        ver = self.iPaps[icepap_name].getVersion(driver_addr, "DRIVER")
         ipap_id = self.iPaps[icepap_name].getId(driver_addr)
         ipap_name = self.iPaps[icepap_name].getName(driver_addr)
         # FIX NON-ASCII CHARS ISSUE IN NAME:
@@ -158,17 +167,20 @@ class IcepapController(Singleton):
         driver_cfg.setParameter(unicode("ID"), ipap_id)
         try:
             driver_cfg.setParameter(unicode("IPAPNAME"), ipap_name)
-        except Exception,e:
-            print 'Exception when trying to write the driver name (%s):' % ipap_name
+        except Exception as e:
+            msg = 'Exception when trying to write the driver name ' \
+                  '(%s):' % ipap_name
+            print msg
             print e
             ipap_name = 'NON-ASCII_NAME'
             driver_cfg.setParameter(unicode("IPAPNAME"), ipap_name)
-        
-        # INSTEAD OF READING PARAM BY PARAM, WE SHOULD ASK THE ICEPAP FOR ALL THE CONFIGURATION
+
+        # INSTEAD OF READING PARAM BY PARAM, WE SHOULD ASK THE ICEPAP FOR
+        # ALL THE CONFIGURATION
         # WITH THE #N?:CFG COMMAND, USING SOME .getCfg() METHOD.
         config = self.iPaps[icepap_name].getCfg(driver_addr)
-        config = config.replace('$\r\n',"")
-        config = config.replace('\r\n$',"")
+        config = config.replace('$\r\n', "")
+        config = config.replace('\r\n$', "")
         params_list = config.split("\r\n")
         for param_value in params_list:
             splitted = param_value.split(" ")
@@ -179,8 +191,9 @@ class IcepapController(Singleton):
             driver_cfg.setParameter(param_name, param_value)
 
         return driver_cfg
-    
-    def setDriverConfiguration(self, icepap_name, driver_addr, new_values, expertFlag = False):
+
+    def setDriverConfiguration(self, icepap_name, driver_addr, new_values,
+                               expertFlag=False):
         """ TO-DO STORM review"""
         if self.iPaps[icepap_name].getMode(driver_addr) != IcepapMode.CONFIG:
             self.iPaps[icepap_name].setConfig(driver_addr)
@@ -189,90 +202,101 @@ class IcepapController(Singleton):
         order_list = self.icepap_cfgorder[icepap_name][driver_addr]
         params_ordered = {}
         not_found_index = []
-        for (name,value) in new_values:
+        for (name, value) in new_values:
             try:
                 index = order_list.index(name)
-                params_ordered[index] = (name,value)
-            except:
-                not_found_index.append((name,value))
-            
+                params_ordered[index] = (name, value)
+            except Exception:
+                not_found_index.append((name, value))
+
         keys = params_ordered.keys()
         keys.sort()
         for key in keys:
-            (name,value) = params_ordered.get(key)
+            (name, value) = params_ordered.get(key)
             if name != "VER":
                 try:
-                    self.iPaps[icepap_name].setCfgParameter(driver_addr, name, str(value))
-                except IcePAPException,iex:
-                    msg = 'Error configuring parameter %s = %s' % (name,str(value))
+                    self.iPaps[icepap_name].setCfgParameter(driver_addr,
+                                                            name, str(value))
+                except IcePAPException as iex:
+                    msg = 'Error configuring parameter %s = %s' % (name,
+                                                                   str(value))
                     msg += '\n'+iex.msg
-                    MessageDialogs.showErrorMessage(None,'Driver conf',msg)
+                    MessageDialogs.showErrorMessage(None, 'Driver conf', msg)
                     print iex.msg
                     raise iex
 
         # NOW THE NOT_FOUND INDEX ORDER...
-        for (name,value) in not_found_index:
+        for (name, value) in not_found_index:
             try:
                 if name == "NAME" or name == "IPAPNAME":
                     name = "NAME"
                     # IN CASE OF NAMELOCK SET TO YES, UNLOCK FIRST
-                    namelock = self.iPaps[icepap_name].getCfgParameter(driver_addr,'NAMELOCK')
+                    namelock = \
+                        self.iPaps[icepap_name].getCfgParameter(driver_addr,
+                                                                'NAMELOCK')
                     if namelock == 'YES':
-                        self.iPaps[icepap_name].setCfgParameter(driver_addr,'NAMELOCK','NO')
-                    self.iPaps[icepap_name].writeParameter(driver_addr, name, str(value))
-                    self.iPaps[icepap_name].setCfgParameter(driver_addr,'NAMELOCK',namelock)
-                elif name in ["VER","ID"]:
+                        self.iPaps[icepap_name].setCfgParameter(driver_addr,
+                                                                'NAMELOCK',
+                                                                'NO')
+                    self.iPaps[icepap_name].writeParameter(driver_addr,
+                                                           name, str(value))
+                    self.iPaps[icepap_name].setCfgParameter(driver_addr,
+                                                            'NAMELOCK',
+                                                            namelock)
+                elif name in ["VER", "ID"]:
                     pass
                 else:
-                    self.iPaps[icepap_name].setCfgParameter(driver_addr, name, str(value))
-            except IcePAPException,iex:
-                msg = 'Error configuring parameter %s = %s' % (name,str(value))
+                    self.iPaps[icepap_name].setCfgParameter(driver_addr,
+                                                            name,
+                                                            str(value))
+            except IcePAPException as iex:
+                msg = 'Error configuring parameter %s = %s' % (name,
+                                                               str(value))
                 msg += '\n'+iex.msg
-                MessageDialogs.showErrorMessage(None,'Driver conf',msg)
+                MessageDialogs.showErrorMessage(None, 'Driver conf', msg)
                 print iex.msg
                 raise iex
-            except Exception,e:
-                print "something happened when configuring the driver",e
-                    
+            except Exception as e:
+                print "something happened when configuring the driver", e
 
         try:
             if expertFlag:
                 self.iPaps[icepap_name].setExpertFlag(driver_addr)
-        except IcePAPException,iex:
+        except IcePAPException as iex:
             msg = 'Error setting expert flag.'
-            msg += '\n'+iex.msg
-            MessageDialogs.showErrorMessage(None,'Expert flag',msg)
+            msg += '\n' + iex.msg
+            MessageDialogs.showErrorMessage(None, 'Expert flag', msg)
             print iex.msg
             raise iex
 
-
-        driver_cfg = self.getDriverConfiguration(icepap_name, driver_addr)    
+        driver_cfg = self.getDriverConfiguration(icepap_name, driver_addr)
         return driver_cfg
-        
-    def discardDriverCfg(self,icepap_name, driver_addr):
+
+    def discardDriverCfg(self, icepap_name, driver_addr):
         try:
-            if self.iPaps.has_key(icepap_name):
+            if icepap_name in self.iPaps:
                 self.iPaps[icepap_name].signConfig(driver_addr, "")
-        except IcePAPException,iex:
+        except IcePAPException as iex:
             msg = 'Error signing config.'
-            msg += '\n'+iex.msg
-            MessageDialogs.showErrorMessage(None,'config',msg)
+            msg += '\n' + iex.msg
+            MessageDialogs.showErrorMessage(None, 'config', msg)
             print iex.msg
             raise iex
-        
-    def signDriverConfiguration(self,icepap_name, driver_addr, signature):
+
+    def signDriverConfiguration(self, icepap_name, driver_addr, signature):
         try:
-            if self.iPaps.has_key(icepap_name):
-                if self.iPaps[icepap_name].getMode(driver_addr) != IcepapMode.CONFIG:
+            if icepap_name in self.iPaps:
+                cfg = IcepapMode.CONFIG
+                if self.iPaps[icepap_name].getMode(driver_addr) != cfg:
                     self.iPaps[icepap_name].setConfig(driver_addr)
                 self.iPaps[icepap_name].signConfig(driver_addr, signature)
-        except IcePAPException,iex:
+        except IcePAPException as iex:
             msg = 'Error signing config.'
-            msg += '\n'+iex.msg
-            MessageDialogs.showErrorMessage(None,'sign driver',msg)
+            msg += '\n' + iex.msg
+            MessageDialogs.showErrorMessage(None, 'sign driver', msg)
             print iex.msg
             raise iex
-   
+
     def startConfiguringDriver(self, icepap_name, driver):
         try:
             mode = self.iPaps[icepap_name].getMode(driver.addr)
@@ -281,18 +305,17 @@ class IcepapController(Singleton):
             if mode != IcepapMode.CONFIG:
                 self.iPaps[icepap_name].setConfig(driver.addr)
             driver.setMode(IcepapMode.CONFIG)
-        except IcePAPException,iex:
+        except IcePAPException as iex:
             msg = 'Error starting config.'
-            msg += '\n'+iex.msg
-            MessageDialogs.showErrorMessage(None,'config',msg)
+            msg += '\n' + iex.msg
+            MessageDialogs.showErrorMessage(None, 'config', msg)
             print iex.msg
             raise iex
         return mode
 
-
-    def endConfiguringDriver( self, icepap_name, driver):
-        try:    
-            if not self.iPaps.has_key(icepap_name):
+    def endConfiguringDriver(self, icepap_name, driver):
+        try:
+            if icepap_name not in self.iPaps:
                 return
             mode = self.iPaps[icepap_name].getMode(driver.addr)
             if mode == IcepapMode.PROG:
@@ -301,275 +324,284 @@ class IcepapController(Singleton):
                 last_signature = self.iPaps[icepap_name].getConfig(driver.addr)
                 self.iPaps[icepap_name].signConfig(driver.addr, last_signature)
             driver.setMode(IcepapMode.OPER)
-        except IcePAPException,iex:
+        except IcePAPException as iex:
             msg = 'Error ending config.'
-            msg += '\n'+iex.msg
-            MessageDialogs.showErrorMessage(None,'end config',msg)
+            msg += '\n' + iex.msg
+            MessageDialogs.showErrorMessage(None, 'end config', msg)
             print iex.msg
             raise iex
 
     def getDriverStatus(self, icepap_name, driver_addr):
         """
-            Returns an array with the Status, Limit Switches and Current of the driver
+        Returns an array with the Status, Limit Switches and Current of the
+        driver
         """
         if not self.iPaps[icepap_name].connected:
-            return (-1,False,-1)
+            return -1, False, -1
 
         if self.programming_ipap is not None:
-            return (-1,False,-1)
-        
+            return -1, False, -1
+
         try:
             register = self.iPaps[icepap_name].getStatus(driver_addr)
             if "x" in register:
-                register = int(register,16)
+                register = int(register, 16)
             else:
                 register = int(register)
-            
+
             power = IcepapStatus.isPowerOn(register)
 
             current = self.iPaps[icepap_name].getCurrent(driver_addr)
-            
+
             state = (int(register), power, float(current))
             return state
-        except Exception,e:
-            #print "There was an exception while accessing the driver ("+icepap_name+":"+str(driver_addr)+"):",e
-            #raise e
-            return (-1, False, -1)
-            
-        
+        except Exception:
+            return -1, False, -1
+
     def getDriverTestStatus(self, icepap_name, driver_addr, pos_sel, enc_sel):
         """
-            Returns an array with the Status, Limit Switches and Position of the driver
+        Returns an array with the Status, Limit Switches and Position of
+        the driver
         """
         if self.programming_ipap is not None:
-            return (-1,-1,[-1,-1])
+            return -1, -1, [-1, -1]
 
         register = self.iPaps[icepap_name].getStatus(driver_addr)
         if "x" in register:
-            register = int(register,16)
+            register = int(register, 16)
         else:
             register = int(register)
 
-        power = False
-        position = -1
-        encoder = -1
-
         power = IcepapStatus.isPowerOn(register)
 
-        position = self.iPaps[icepap_name].getPositionFromBoard(driver_addr, pos_sel)
+        position = self.iPaps[icepap_name].getPositionFromBoard(driver_addr,
+                                                                pos_sel)
         encoder = self.iPaps[icepap_name].getEncoder(driver_addr, enc_sel)
 
         try:
             encoder = float(encoder)
-        except:
+        except Exception:
             encoder = -1
         try:
             position = float(position)
-        except:
+        except Exception:
             position = -1
         posarray = [position, encoder]
-            
+
         state = (int(register), power, posarray)
         return state
-        
+
     def getDriverActiveStatus(self, icepap_name, driver_addr):
         try:
             return self.iPaps[icepap_name].getActive(driver_addr)
-        except IcePAPException,iex:
+        except IcePAPException as iex:
             msg = 'Error reading active status.'
-            msg += '\n'+iex.msg
-            MessageDialogs.showErrorMessage(None,'get active',msg)
+            msg += '\n' + iex.msg
+            MessageDialogs.showErrorMessage(None, 'get active', msg)
             print iex.msg
             raise iex
 
     def readIcepapParameters(self, icepap_name, driver_addr, par_list):
         try:
-           values = []
-           for name in par_list:
-               if type(name) == type(values):
-                   value = self.iPaps[icepap_name].readParameter(driver_addr, name[0], name[1])
-               else:
-                   value = self.iPaps[icepap_name].readParameter(driver_addr, name)
-               values.append([name, value])
-           
-           return values
-        except IcePAPException,iex:
-            msg = 'Error reading parameters for driver %s.'%(str(driver_addr))
-            msg += '\n'+iex.msg
-            MessageDialogs.showErrorMessage(None,'read param',msg)
+            values = []
+            for name in par_list:
+                if type(name) == type(values):
+                    value = self.iPaps[icepap_name].readParameter(driver_addr,
+                                                                  name[0],
+                                                                  name[1])
+                else:
+                    value = self.iPaps[icepap_name].readParameter(
+                        driver_addr, name)
+                values.append([name, value])
+
+            return values
+        except IcePAPException as iex:
+            msg = 'Error reading parameters for driver %s.' % (str(
+                driver_addr))
+            msg += '\n' + iex.msg
+            MessageDialogs.showErrorMessage(None, 'read param', msg)
             print iex.msg
             raise iex
 
-    
     def writeIcepapParameters(self, icepap_name, driver_addr, par_var_list):
-        values = []
         # THE CONFIGURATION VALUES SHOULD BE SENT IN A SPECIFIC ORDER
         order_list = self.icepap_cfgorder[icepap_name][driver_addr]
         params_ordered = {}
         not_found_index = []
-        for (name,value) in par_var_list:
+        for (name, value) in par_var_list:
             try:
                 index = order_list.index(name)
-                params_ordered[index] = (name,value)
-            except:
-                not_found_index.append((name,value))
-        
+                params_ordered[index] = (name, value)
+            except Exception:
+                not_found_index.append((name, value))
+
         keys = params_ordered.keys()
         keys.sort()
         for key in keys:
-            (name,value) = params_ordered.get(key)
+            (name, value) = params_ordered.get(key)
             try:
-                self.iPaps[icepap_name].writeParameter(driver_addr, name, value)
-            except IcePAPException,iex:
-                msg = 'Error writing icepap parameter %s = %s.' % (name,str(value))
+                self.iPaps[icepap_name].writeParameter(driver_addr, name,
+                                                       value)
+            except IcePAPException as iex:
+                msg = 'Error writing icepap parameter %s = %s.' % (name,
+                                                                   str(value))
                 msg += '\n'+iex.msg
-                MessageDialogs.showErrorMessage(None,'write param',msg)
+                MessageDialogs.showErrorMessage(None, 'write param', msg)
                 print iex.msg
                 raise iex
-        
+
         # NOW THE NOT FOUND INDEX ORDER...
-        for (name,value) in not_found_index:
+        for (name, value) in not_found_index:
             try:
-                self.iPaps[icepap_name].writeParameter(driver_addr,name,value)
-            except IcePAPException,iex:
-                msg = 'Error writing icepap parameter %s = %s.' % (name,str(value))
-                msg += '\n'+iex.msg
-                MessageDialogs.showErrorMessage(None,'write param',msg)
+                self.iPaps[icepap_name].writeParameter(driver_addr,
+                                                       name,
+                                                       value)
+            except IcePAPException as iex:
+                msg = 'Error writing icepap parameter %s = %s.' % (name,
+                                                                   str(value))
+                msg += '\n' + iex.msg
+                MessageDialogs.showErrorMessage(None, 'write param', msg)
                 print iex.msg
                 raise iex
 
-
-    def configDriverToDefaults(self,icepap_name,driver_addr):
+    def configDriverToDefaults(self, icepap_name, driver_addr):
         try:
             self.iPaps[icepap_name].setDefaultConfig(driver_addr)
-        except IcePAPException,iex:
+        except IcePAPException as iex:
             msg = 'Error configuring to defaults.'
-            msg += '\n'+iex.msg
-            MessageDialogs.showErrorMessage(None,'default config',msg)
+            msg += '\n' + iex.msg
+            MessageDialogs.showErrorMessage(None, 'default config', msg)
             print iex.msg
             raise iex
 
-    def getDriverCfgInfo(self,icepap_name,driver_addr):
+    def getDriverCfgInfo(self, icepap_name, driver_addr):
         try:
             cfginfo = self.iPaps[icepap_name].getCfgInfo(driver_addr)
             return cfginfo
-        except IcePAPException,iex:
+        except IcePAPException as iex:
             msg = 'Error getting cfginfo (%s).' % (str(driver_addr))
-            msg += '\n'+iex.msg
-            MessageDialogs.showErrorMessage(None,'cfg info',msg)
+            msg += '\n' + iex.msg
+            MessageDialogs.showErrorMessage(None, 'cfg info', msg)
             print iex.msg
             raise iex
 
-
     def getDriverCfgInfoDictAndList(self, icepap_name, driver_addr):
         """
-            Returns a dictionary with all the Driver params cfginfo
+        Returns a dictionary with all the Driver params cfginfo
         """
-        
-        """ TO-DO STORM review"""   
-        # THE AVAILABLE OPTIONS FOR EACH PARAMETER ARE ALSO GIVEN BY THE DRIVER INSTEAD OF
-        # FIXED VALUES FROM THE APPLICATION
-        # THE CFGINFO IS NEEDED TO POPULATE THE QComboBoxes with correct available values
-        cfginfo_str = self.getDriverCfgInfo(icepap_name,driver_addr)
-        cfginfo_str = cfginfo_str.replace('$\r\n',"")
-        cfginfo_str = cfginfo_str.replace('\r\n$',"")
+
+        """ TO-DO STORM review"""
+        # THE AVAILABLE OPTIONS FOR EACH PARAMETER ARE ALSO GIVEN BY THE
+        # DRIVER INSTEAD OF FIXED VALUES FROM THE APPLICATION
+        # THE CFGINFO IS NEEDED TO POPULATE THE QComboBoxes with correct
+        # available values
+        cfginfo_str = self.getDriverCfgInfo(icepap_name, driver_addr)
+        cfginfo_str = cfginfo_str.replace('$\r\n', "")
+        cfginfo_str = cfginfo_str.replace('\r\n$', "")
         cfginfo_list = cfginfo_str.split("\r\n")
         cfginfo_dict = {}
         order_list = []
         for param_cfg in cfginfo_list:
-            split = param_cfg.split(" ",1)
+            split = param_cfg.split(" ", 1)
             if len(split) > 1:
                 param = split[0]
                 values = split[1]
-                values = values.replace("{","")
-                values = values.replace("}","")
+                values = values.replace("{", "")
+                values = values.replace("}", "")
                 cfginfo_dict[split[0]] = values.split()
                 order_list.append(param)
             else:
-                print "THE CONTROLLER DID NOT RECEIVE ALL THE CFGINFO FOR THE DRIVER "+str(driver_addr)
-                print "PLEASE, TRY TO RECONNECT TO THE "+str(icepap_name)+" ICEPAP SYSTEM"
+                print("THE CONTROLLER DID NOT RECEIVE ALL THE CFGINFO FOR "
+                      "THE DRIVER "+str(driver_addr))
+                print("PLEASE, TRY TO RECONNECT TO THE " +
+                      str(icepap_name)+" ICEPAP SYSTEM")
                 print "AND REPORT THIS OUTPUT TO THE MANTAINER\n\n\n"
-                
-                MessageDialogs.showWarningMessage(None, "Driver configuration", "Could not retrive all the CFGINFO for the driver "+str(driver_addr)+". Please, try to reconnect to "+str(icepap_name)+".")
-                #print "ALL INFO WAS (str): "+str(cfginfo_str)
-                #print "ALL INFO WAS (list): "+str(cfginfo_list)
-                #print "SOME ERROR GETTING CFGINFO: "+str(param_cfg)
-        return (cfginfo_dict,order_list)
 
-    
+                msg = "Could not retrive all the CFGINFO for the driver "\
+                      + str(driver_addr)\
+                      + ". Please, try to reconnect to "\
+                      + str(icepap_name)+"."
+                MessageDialogs.showWarningMessage(None,
+                                                  "Driver configuration",
+                                                  msg)
+                # print "ALL INFO WAS (str): "+str(cfginfo_str)
+                # print "ALL INFO WAS (list): "+str(cfginfo_list)
+                # print "SOME ERROR GETTING CFGINFO: "+str(param_cfg)
+        return cfginfo_dict, order_list
+
     def getDriverMotionValues(self, icepap_name, driver_addr):
         speed = self.iPaps[icepap_name].getSpeed(driver_addr)
         acc = self.iPaps[icepap_name].getAcceleration(driver_addr)
         state = (speed, acc)
         return state
-            
-    
+
     def setDriverMotionValues(self, icepap_name, driver_addr, values):
         try:
             self.iPaps[icepap_name].setSpeed(driver_addr, values[0])
             self.iPaps[icepap_name].setAcceleration(driver_addr, values[1])
             return 0
-        except:
+        except Exception:
             return -1
+
     def setDriverPosition(self, icepap_name, driver_addr, pos_sel, position):
         try:
             self.iPaps[icepap_name].setPosition(driver_addr, position, pos_sel)
             return 0
-        except:
+        except Exception:
             return -1
-    
+
     def setDriverEncoder(self, icepap_name, driver_addr, enc_sel, position):
         try:
             self.iPaps[icepap_name].setEncoder(driver_addr, position, enc_sel)
             return 0
-        except:
+        except Exception:
             return -1
-        
+
     def moveDriver(self, icepap_name, driver_addr, steps):
-        
+
         if self.iPaps[icepap_name].getMode(driver_addr) == IcepapMode.CONFIG:
             # CMOVE ONLY ALLOWS ABSOLUTE POSITIONS, IT SHOULD BE CALCULATED
-            #self.iPaps[icepap_name].cmove(driver_addr, steps)
+            # self.iPaps[icepap_name].cmove(driver_addr, steps)
             pos = self.iPaps[icepap_name].getPosition(driver_addr)
             new_pos = int(pos) + int(steps)
             self.iPaps[icepap_name].cmove(driver_addr, new_pos)
         else:
             self.iPaps[icepap_name].rmove(driver_addr, steps)
-        
+
     def moveDriverAbsolute(self, icepap_name, driver_addr, pos):
         if self.iPaps[icepap_name].getMode(driver_addr) == IcepapMode.CONFIG:
             self.iPaps[icepap_name].cmove(driver_addr, pos)
         else:
             self.iPaps[icepap_name].move(driver_addr, pos)
-        
+
     def stopDriver(self, icepap_name, driver_addr):
         self.iPaps[icepap_name].stop(driver_addr)
-    
+
     def abortDriver(self, icepap_name, driver_addr):
         self.iPaps[icepap_name].abort(driver_addr)
 
-    def blinkDriver(self, icepap_name, driver_addr,secs):
-        self.iPaps[icepap_name].blink(driver_addr,secs)
-    
+    def blinkDriver(self, icepap_name, driver_addr, secs):
+        self.iPaps[icepap_name].blink(driver_addr, secs)
+
     def jogDriver(self, icepap_name, driver_addr, speed):
         if self.iPaps[icepap_name].getMode(driver_addr) != IcepapMode.CONFIG:
             self.iPaps[icepap_name].jog(driver_addr, speed)
         else:
             self.iPaps[icepap_name].cjog(driver_addr, speed)
-    
+
     def enableDriver(self, icepap_name, driver_addr):
         self.iPaps[icepap_name].enable(driver_addr)
-    
+
     def disableDriver(self, icepap_name, driver_addr):
         self.iPaps[icepap_name].disable(driver_addr)
-    
+
     def checkIcepapStatus(self, icepap_name):
-        if self.iPaps.has_key(icepap_name) and not self.iPaps[icepap_name].connected:
+        if icepap_name in self.iPaps and not self.iPaps[icepap_name].connected:
             return False
-        if not self.iPaps.has_key(icepap_name):
+        if icepap_name not in self.iPaps:
             return False
         return True
-        
+
     def _checkDriverStatus(self, icepap_name, driver_addr):
         """
             Check the status of a Icepap Driver
@@ -579,48 +611,51 @@ class IcepapController(Singleton):
         """
         try:
             return self.iPaps[icepap_name].checkDriver(driver_addr)
-        except:
+        except Exception:
             print "Unexpected error:", sys.exc_info()[0]
             return -1
-        
+
     def _getDriverAddr(self, cratenr, drivernr):
         """
             returns (cratenr * 10) + drivernr
         """
         return (cratenr * 10) + drivernr
-    
+
     def _parseDriverTemplateFile(self):
         self.config_parameters = []
         doc = minidom.parse(self.config_template)
-        root  = doc.documentElement
+        root = doc.documentElement
         for section in root.getElementsByTagName("section"):
             if section.nodeType == Node.ELEMENT_NODE:
-                    section_name =  section.attributes.get('name').value
+                    section_name = section.attributes.get('name').value
             inTestSection = (section_name == "test")
             if not inTestSection:
                 for pars in section.getElementsByTagName("par"):
                     if pars.nodeType == Node.ELEMENT_NODE:
-                        parname =  pars.attributes.get('name').value
+                        parname = pars.attributes.get('name').value
                         self.config_parameters.append(str(parname))
-        
+
     def getSerialPorts(self):
         try:
             return IcePAP.serialScan()
-        except:
+        except Exception:
             return []
 
-    def upgradeDrivers(self,icepap_name,progress_dialog):
+    def upgradeDrivers(self, icepap_name, progress_dialog):
         if self.programming_ipap is not None:
             return False
         self.programming_ipap = self.iPaps[icepap_name]
         self.progress_dialog = progress_dialog
         self.progress_dialog.show()
         self.updateProgressBarTimer = Qt.QTimer()
-        QtCore.QObject.connect(self.updateProgressBarTimer,QtCore.SIGNAL("timeout()"),self.updateProgressBar)
+        QtCore.QObject.connect(self.updateProgressBarTimer,
+                               QtCore.SIGNAL("timeout()"),
+                               self.updateProgressBar)
         cmd = "#MODE PROG"
         answer = self.programming_ipap.sendWriteReadCommand(cmd)
         if answer != "MODE OK":
-            print "icepapcontroller:upgradeDrivers:Some error trying to set mode PROG:",answer
+            print("icepapcontroller:upgradeDrivers:Some error trying to set "
+                  "mode PROG:", answer)
             return False
         cmd = "PROG DRIVERS"
         self.programming_ipap.sendWriteCommand(cmd, prepend_ack=False)
@@ -635,28 +670,28 @@ class IcepapController(Singleton):
             self.progress_dialog.setValue(100)
             self.updateProgressBarTimer.stop()
             cmd = "#MODE OPER"
-            answer = self.programming_ipap.sendWriteReadCommand(cmd)
-            self.programming_ipap = None    
-         
-        ##cmd = "?PROG"
-        ##answer = self.programming_ipap.sendWriteReadCommand(cmd)
-        ##if answer.count("ACTIVE") > 0:
-        ##    p = int(answer.split(" ")[2].split(".")[0])
-        ##    self.progress_dialog.setValue(p)
-        ##else:
-        ##    self.progress_dialog.setValue(100)
-        ##    self.updateProgressBarTimer.stop()
-        ##    cmd = "#MODE OPER"
-        ##    answer = self.programming_ipap.sendWriteReadCommand(cmd)
-        ##    self.programming_ipap = None
-        
+            self.programming_ipap.sendWriteReadCommand(cmd)
+            self.programming_ipap = None
+
+        # cmd = "?PROG"
+        # answer = self.programming_ipap.sendWriteReadCommand(cmd)
+        # if answer.count("ACTIVE") > 0:
+        #     p = int(answer.split(" ")[2].split(".")[0])
+        #     self.progress_dialog.setValue(p)
+        # else:
+        #     self.progress_dialog.setValue(100)
+        #     self.updateProgressBarTimer.stop()
+        #     cmd = "#MODE OPER"
+        #     answer = self.programming_ipap.sendWriteReadCommand(cmd)
+        #     self.programming_ipap = None
+
     def sendFirmware(self, ipap, filename, logger, save=True):
         logger.addToLog("Setting MODE PROG")
         cmd = "#MODE PROG"
         logger.addToLog(cmd)
         ans = ipap.sendWriteReadCommand(cmd)
         logger.addToLog(ans)
-        
+
         logger.addToLog("Transferring firmware")
         ipap.sendFirmware(filename, save=save)
 
@@ -678,9 +713,9 @@ class IcepapController(Singleton):
             else:
                 host = dst
                 port = "5000"
-            
-            ipap = EthIcePAP(host , port)
-            
+
+            ipap = EthIcePAP(host, port)
+
         addr = addr.replace("NONE", "")
         options = options.replace("NONE", "")
         ipap.connect()
@@ -697,14 +732,13 @@ class IcepapController(Singleton):
         logger.addToLog(cmd)
         ans = ipap.sendWriteReadCommand(cmd)
         logger.addToLog(ans)
-        
-        
+
         logger.addToLog("Configuring connection: "+addr+","+options)
-        
+
         cmd = "PROG %s %s" % (addr, options)
         logger.addToLog(cmd)
         ipap.sendWriteCommand(cmd, prepend_ack=False)
-        
+
         shouldwait = True
         while shouldwait:
             p = ipap.getProgressStatus()
@@ -713,37 +747,35 @@ class IcepapController(Singleton):
             elif isinstance(p, int):
                 logger.addToLog('Programming %d %%' % p)
                 time.sleep(5)
-        
+
         logger.addToLog("Setting MODE OPER")
         cmd = "#MODE OPER"
         logger.addToLog(cmd)
         ans = ipap.sendWriteReadCommand(cmd)
         logger.addToLog(ans)
 
-        #if addr == 'ALL':
-        if True:
-            logger.addToLog('SHOULD BE ONLY IF %s IS ALL' % addr)
-            logger.addToLog('Wait while rebooting... (25-30) secs')
-            cmd = '#REBOOT'
-            logger.addToLog(cmd)
-            ans = ipap.sendWriteReadCommand(cmd)
-            logger.addToLog(ans)
+        logger.addToLog('SHOULD BE ONLY IF %s IS ALL' % addr)
+        logger.addToLog('Wait while rebooting... (25-30) secs')
+        cmd = '#REBOOT'
+        logger.addToLog(cmd)
+        ans = ipap.sendWriteReadCommand(cmd)
+        logger.addToLog(ans)
 
-            # WE SHOULD WAIT UNTIL CONNECTION IS LOST
-            secs = 0
-            for i in range(10):
-                time.sleep(1)
-                secs += 1
-                if (secs % 5) == 0:
-                    logger.addToLog('Waiting... (%2d secs).' % secs)
-            ipap.disconnect()
+        # WE SHOULD WAIT UNTIL CONNECTION IS LOST
+        secs = 0
+        for i in range(10):
+            time.sleep(1)
+            secs += 1
+            if (secs % 5) == 0:
+                logger.addToLog('Waiting... (%2d secs).' % secs)
+        ipap.disconnect()
 
-            # WE SHOULD WAIT UNTIL ICEPAP IS RECONNECTED
-            while not ipap.connected:
-                time.sleep(1)
-                secs += 1
-                if (secs % 5) == 0:
-                    logger.addToLog('Waiting... (%2d secs).' % secs)
+        # WE SHOULD WAIT UNTIL ICEPAP IS RECONNECTED
+        while not ipap.connected:
+            time.sleep(1)
+            secs += 1
+            if (secs % 5) == 0:
+                logger.addToLog('Waiting... (%2d secs).' % secs)
 
         cmd = '0:?VER INFO'
         logger.addToLog(cmd)
@@ -751,7 +783,6 @@ class IcepapController(Singleton):
         logger.addToLog(ans)
         logger.addToLog('\n\nProgramming sequence done!')
 
-    
     def testConnection(self, serial, dst):
         try:
             if serial:
@@ -764,69 +795,78 @@ class IcepapController(Singleton):
                 else:
                     host = dst
                     port = "5000"
-                ipap = EthIcePAP(host , port)
+                ipap = EthIcePAP(host, port)
             ipap.connect()
-            #ver = ipap.getVersionDsp(0)
-            ver = ipap.getSystemVersion()
+            ipap.getSystemVersion()
             print "testing connection"
             ipap.disconnect()
             return True
-        except:
+        except Exception:
             return False
 
+    def find_networks(self, configs, addr_pattern, mask_pattern):
+        addr_parse = re.compile(addr_pattern)
+        mask_parse = re.compile(mask_pattern)
+        networks = []
+        for config in configs:
+            addr = addr_parse.search(config)
+            mask = mask_parse.search(config)
+            if addr and mask:
+                net = IP(addr.group(2)+"/"+mask.group(2), make_net=True)
+                networks.append(net)
+        return networks
 
-    def find_networks(self,configs,addr_pattern,mask_pattern):
-      addr_parse = re.compile(addr_pattern)
-      mask_parse = re.compile(mask_pattern)
-      networks = []
-      for config in configs:
-          addr = addr_parse.search(config)
-          mask = mask_parse.search(config)
-          if addr and mask:
-              net = IP(addr.group(2)+"/"+mask.group(2),make_net=True)
-              networks.append(net)
-      return networks
-  
-    def host_in_same_subnet(self,host):
-          if self._config._options.allnets:
-              return True
-  
-          networks = []
-          configs = None
-          addr_pattern = None
-          mask_pattern = None
-          digits = r'[0-9]{1,3}'
-          
-          if os.name == 'posix':
-              ifconfigs = ['/sbin/ifconfig','/usr/sbin/ifconfig','/bin/ifconfig','/usr/bin/ifconfig']
-              ifconfig = filter(os.path.exists,ifconfigs)[0]
-              fp = os.popen(ifconfig+' -a')
-              configs = fp.read().split('\n\n')
-              fp.close()
-              # 180214 - Adapted to Debian9 "/sbin/ifconfig -a" output
-              #addr_pattern = r'(inet addr:) *(%s\.%s\.%s\.%s)[^0-9]' % ((digits,)*4)
-              #mask_pattern = r'(Mask:) *(%s\.%s\.%s\.%s)[^0-9]' % ((digits,)*4)
-              addr_pattern = r'(inet ) *(%s\.%s\.%s\.%s)[^0-9]' % ((digits,)*4)
-              mask_pattern = r'(netmask ) *(%s\.%s\.%s\.%s)[^0-9]' % ((digits,)*4)
-          elif os.name == 'nt':
-              fp = os.popen('ipconfig /all')
-              configs = fp.read().split(':\r\n\r\n')
-              fp.close()
-              # 180214 - Adapted to Windows7 "ipconfig /all" output
-              #addr_pattern = r'(IP Address).*: (%s\.%s\.%s\.%s)[^0-9]' % ((digits,)*4)
-              addr_pattern = r'(IPv4 Address).*: (%s\.%s\.%s\.%s)[^0-9]' % ((digits,)*4)
-              mask_pattern = r'(Subnet Mask).*: (%s\.%s\.%s\.%s)[^0-9]' % ((digits,)*4)
-  
-          if configs and addr_pattern and mask_pattern:
-              networks = self.find_networks(configs,addr_pattern,mask_pattern)
-  
-          if len(networks)>0:
-              host_addr = socket.gethostbyname(host)
-              for net in networks:
-                  if host_addr in net:
-                      return True
-              return False            
-          else:
-              MessageDialogs.showInformationMessage(None,"Not posix operating system","Sorry system not yet supported.\nWe allow you access to the icepap even if it is in another subnet.")
-              return True
-        
+    def host_in_same_subnet(self, host):
+        if self._config._options.allnets:
+            return True
+
+        networks = []
+        configs = None
+        addr_pattern = None
+        mask_pattern = None
+        digits = r'[0-9]{1,3}'
+
+        if os.name == 'posix':
+            ifconfigs = ['/sbin/ifconfig', '/usr/sbin/ifconfig',
+                         '/bin/ifconfig', '/usr/bin/ifconfig']
+            ifconfig = filter(os.path.exists, ifconfigs)[0]
+            fp = os.popen(ifconfig+' -a')
+            configs = fp.read().split('\n\n')
+            fp.close()
+            # 180214 - Adapted to Debian9 "/sbin/ifconfig -a" output
+            # addr_pattern = r'(inet addr:) *(%s\.%s\.%s\.%s)[^0-9]' \
+            #   % ((digits,)*4)
+            # mask_pattern = r'(Mask:) *(%s\.%s\.%s\.%s)[^0-9]' \
+            #   % ((digits,)*4)
+            addr_pattern = r'(inet ) *(%s\.%s\.%s\.%s)' \
+                           r'[^0-9]' % ((digits,)*4)
+            mask_pattern = r'(netmask ) *(%s\.%s\.%s\.%s)' \
+                           r'[^0-9]' % ((digits,)*4)
+        elif os.name == 'nt':
+            fp = os.popen('ipconfig /all')
+            configs = fp.read().split(':\r\n\r\n')
+            fp.close()
+            # 180214 - Adapted to Windows7 "ipconfig /all" output
+            # addr_pattern = r'(IP Address).*: (%s\.%s\.%s\.%s)[^0-9]' % ((
+            # digits,)*4)
+            addr_pattern = r'(IPv4 Address).*: (%s\.%s\.%s\.%s)' \
+                           r'[^0-9]' % ((digits,)*4)
+            mask_pattern = r'(Subnet Mask).*: (%s\.%s\.%s\.%s)' \
+                           r'[^0-9]' % ((digits,)*4)
+
+        if configs and addr_pattern and mask_pattern:
+            networks = self.find_networks(configs, addr_pattern, mask_pattern)
+
+        if len(networks) > 0:
+            host_addr = socket.gethostbyname(host)
+            for net in networks:
+                if host_addr in net:
+                    return True
+            return False
+        else:
+            msg = "Sorry system not yet supported.\nWe allow you access to " \
+                  "the icepap even if it is in another subnet."
+            MessageDialogs.showInformationMessage(None,
+                                                  "Not posix operating system",
+                                                  msg)
+            return True

--- a/icepapCMS/lib_icepapcms/icepapcontroller.py
+++ b/icepapCMS/lib_icepapcms/icepapcontroller.py
@@ -17,14 +17,11 @@ from xml.dom import minidom, Node
 import os
 import sys
 from singleton import Singleton
-import time
 import datetime
 from icepapdrivercfg import IcepapDriverCfg
 import icepapdriver
 from configmanager import ConfigManager
 from ..ui_icepapcms.messagedialogs import MessageDialogs
-from PyQt4 import QtCore
-from PyQt4 import Qt
 import re
 import socket
 from IPy import IP

--- a/icepapCMS/lib_icepapcms/icepapcontroller.py
+++ b/icepapCMS/lib_icepapcms/icepapcontroller.py
@@ -11,8 +11,7 @@
 # ------------------------------------------------------------------------------
 
 
-from pyIcePAP import IcepapMode, IcePAPException, IcePAP, EthIcePAP, \
-    SerialIcePAP, IcepapStatus
+from pyIcePAP import EthIcePAPController, Mode
 from xml.dom import minidom, Node
 import os
 import sys
@@ -60,9 +59,10 @@ class IcepapController(Singleton):
         self.iPaps = {}
 
     def openConnection(self, icepap_name, host, port):
-        log_folder = None
-        if self.debug:
-            log_folder = self.log_folder
+        # TODO: Configure logging
+        # log_folder = None
+        # if self.debug:
+        #     log_folder = self.log_folder
         if not self.host_in_same_subnet(icepap_name):
             MessageDialogs.showInformationMessage(None, "Host connection",
                                                   "It is not allowed to "
@@ -71,9 +71,8 @@ class IcepapController(Singleton):
             return False
         else:
             try:
-                self.iPaps[icepap_name] = EthIcePAP(host, port,
-                                                    log_path=log_folder)
-                self.iPaps[icepap_name].connect()
+                # TODO: Configure logging log_path=log_folder
+                self.iPaps[icepap_name] = EthIcePAPController(host, port)
                 return True
             except Exception:
                 return False

--- a/icepapCMS/lib_icepapcms/icepapcontroller.py
+++ b/icepapCMS/lib_icepapcms/icepapcontroller.py
@@ -474,61 +474,6 @@ class IcepapController(Singleton):
             print iex.msg
             raise iex
 
-    def getDriverCfgInfo(self, icepap_name, driver_addr):
-        try:
-            cfginfo = self.iPaps[icepap_name].getCfgInfo(driver_addr)
-            return cfginfo
-        except IcePAPException as iex:
-            msg = 'Error getting cfginfo (%s).' % (str(driver_addr))
-            msg += '\n' + iex.msg
-            MessageDialogs.showErrorMessage(None, 'cfg info', msg)
-            print iex.msg
-            raise iex
-
-    def getDriverCfgInfoDictAndList(self, icepap_name, driver_addr):
-        """
-        Returns a dictionary with all the Driver params cfginfo
-        """
-
-        """ TO-DO STORM review"""
-        # THE AVAILABLE OPTIONS FOR EACH PARAMETER ARE ALSO GIVEN BY THE
-        # DRIVER INSTEAD OF FIXED VALUES FROM THE APPLICATION
-        # THE CFGINFO IS NEEDED TO POPULATE THE QComboBoxes with correct
-        # available values
-        cfginfo_str = self.getDriverCfgInfo(icepap_name, driver_addr)
-        cfginfo_str = cfginfo_str.replace('$\r\n', "")
-        cfginfo_str = cfginfo_str.replace('\r\n$', "")
-        cfginfo_list = cfginfo_str.split("\r\n")
-        cfginfo_dict = {}
-        order_list = []
-        for param_cfg in cfginfo_list:
-            split = param_cfg.split(" ", 1)
-            if len(split) > 1:
-                param = split[0]
-                values = split[1]
-                values = values.replace("{", "")
-                values = values.replace("}", "")
-                cfginfo_dict[split[0]] = values.split()
-                order_list.append(param)
-            else:
-                print("THE CONTROLLER DID NOT RECEIVE ALL THE CFGINFO FOR "
-                      "THE DRIVER "+str(driver_addr))
-                print("PLEASE, TRY TO RECONNECT TO THE " +
-                      str(icepap_name)+" ICEPAP SYSTEM")
-                print "AND REPORT THIS OUTPUT TO THE MANTAINER\n\n\n"
-
-                msg = "Could not retrive all the CFGINFO for the driver "\
-                      + str(driver_addr)\
-                      + ". Please, try to reconnect to "\
-                      + str(icepap_name)+"."
-                MessageDialogs.showWarningMessage(None,
-                                                  "Driver configuration",
-                                                  msg)
-                # print "ALL INFO WAS (str): "+str(cfginfo_str)
-                # print "ALL INFO WAS (list): "+str(cfginfo_list)
-                # print "SOME ERROR GETTING CFGINFO: "+str(param_cfg)
-        return cfginfo_dict, order_list
-
     def getDriverMotionValues(self, icepap_name, driver_addr):
         speed = self.iPaps[icepap_name].getSpeed(driver_addr)
         acc = self.iPaps[icepap_name].getAcceleration(driver_addr)
@@ -602,24 +547,12 @@ class IcepapController(Singleton):
             return False
         return True
 
-    def _checkDriverStatus(self, icepap_name, driver_addr):
-        """
-            Check the status of a Icepap Driver
-             0 - Disabled
-             1 - Enabled
-            -1 - Not Present
-        """
         try:
             return self.iPaps[icepap_name].checkDriver(driver_addr)
         except Exception:
             print "Unexpected error:", sys.exc_info()[0]
             return -1
 
-    def _getDriverAddr(self, cratenr, drivernr):
-        """
-            returns (cratenr * 10) + drivernr
-        """
-        return (cratenr * 10) + drivernr
 
     def _parseDriverTemplateFile(self):
         self.config_parameters = []

--- a/icepapCMS/lib_icepapcms/icepapcontroller.py
+++ b/icepapCMS/lib_icepapcms/icepapcontroller.py
@@ -558,42 +558,50 @@ class IcepapController(Singleton):
                         self.config_parameters.append(str(parname))
 
     def getSerialPorts(self):
-        try:
-            return IcePAP.serialScan()
-        except Exception:
-            return []
+        # TODO: Implement scanning of the serials ports
+        return []
+        # try:
+        #     #return IcePAP.serialScan()
+        # except Exception:
+        #     return []
+
+    def _update_error_msg(self):
+        msg = 'Update driver is underdevelopment. In the meantime use ' \
+              'pyIcePAP command line script to update the firmware and drivers'
+        raise NotImplementedError(msg)
 
     def upgradeDrivers(self, icepap_name, progress_dialog):
-        if self.programming_ipap is not None:
-            return False
-        self.programming_ipap = self.iPaps[icepap_name]
-        self.progress_dialog = progress_dialog
-        self.progress_dialog.show()
-        self.updateProgressBarTimer = Qt.QTimer()
-        QtCore.QObject.connect(self.updateProgressBarTimer,
-                               QtCore.SIGNAL("timeout()"),
-                               self.updateProgressBar)
-        cmd = "#MODE PROG"
-        answer = self.programming_ipap.sendWriteReadCommand(cmd)
-        if answer != "MODE OK":
-            print("icepapcontroller:upgradeDrivers:Some error trying to set "
-                  "mode PROG:", answer)
-            return False
-        cmd = "PROG DRIVERS"
-        self.programming_ipap.sendWriteCommand(cmd, prepend_ack=False)
-        self.updateProgressBarTimer.start(2000)
-        return True
+        self._update_error_msg()
+        # if self.programming_ipap is not None:
+        #     return False
+        # self.programming_ipap = self.iPaps[icepap_name]
+        # self.progress_dialog = progress_dialog
+        # self.progress_dialog.show()
+        # self.updateProgressBarTimer = Qt.QTimer()
+        # QtCore.QObject.connect(self.updateProgressBarTimer,
+        #                        QtCore.SIGNAL("timeout()"),
+        #                        self.updateProgressBar)
+        # cmd = "#MODE PROG"
+        # answer = self.programming_ipap.sendWriteReadCommand(cmd)
+        # if answer != "MODE OK":
+        #     print("icepapcontroller:upgradeDrivers:Some error trying to set "
+        #           "mode PROG:", answer)
+        #     return False
+        # cmd = "PROG DRIVERS"
+        # self.programming_ipap.sendWriteCommand(cmd, prepend_ack=False)
+        # self.updateProgressBarTimer.start(2000)
+        # return True
 
-    def updateProgressBar(self):
-        progress = self.programming_ipap.getProgressStatus()
-        if progress is not None:
-            self.progress_dialog.setValue(progress)
-        else:
-            self.progress_dialog.setValue(100)
-            self.updateProgressBarTimer.stop()
-            cmd = "#MODE OPER"
-            self.programming_ipap.sendWriteReadCommand(cmd)
-            self.programming_ipap = None
+    # def updateProgressBar(self):
+    #     progress = self.programming_ipap.getProgressStatus()
+    #     if progress is not None:
+    #         self.progress_dialog.setValue(progress)
+    #     else:
+    #         self.progress_dialog.setValue(100)
+    #         self.updateProgressBarTimer.stop()
+    #         cmd = "#MODE OPER"
+    #         self.programming_ipap.sendWriteReadCommand(cmd)
+    #         self.programming_ipap = None
 
         # cmd = "?PROG"
         # answer = self.programming_ipap.sendWriteReadCommand(cmd)
@@ -608,26 +616,112 @@ class IcepapController(Singleton):
         #     self.programming_ipap = None
 
     def sendFirmware(self, ipap, filename, logger, save=True):
-        logger.addToLog("Setting MODE PROG")
-        cmd = "#MODE PROG"
-        logger.addToLog(cmd)
-        ans = ipap.sendWriteReadCommand(cmd)
-        logger.addToLog(ans)
-
-        logger.addToLog("Transferring firmware")
-        ipap.sendFirmware(filename, save=save)
-
-        time.sleep(5)
-        ipap.sendWriteCommand("MODE OPER")
-        cmd = "#MODE OPER"
-        logger.addToLog(cmd)
-        ans = ipap.sendWriteReadCommand(cmd)
-        logger.addToLog(ans)
+        self._update_error_msg()
+        # logger.addToLog("Setting MODE PROG")
+        # cmd = "#MODE PROG"
+        # logger.addToLog(cmd)
+        # ans = ipap.sendWriteReadCommand(cmd)
+        # logger.addToLog(ans)
+        #
+        # logger.addToLog("Transferring firmware")
+        # ipap.sendFirmware(filename, save=save)
+        #
+        # time.sleep(5)
+        # ipap.sendWriteCommand("MODE OPER")
+        # cmd = "#MODE OPER"
+        # logger.addToLog(cmd)
+        # ans = ipap.sendWriteReadCommand(cmd)
+        # logger.addToLog(ans)
 
     def upgradeFirmware(self, serial, dst, filename, addr, options, logger):
-        if serial:
-            ipap = SerialIcePAP(dst, 0)
-        else:
+        self._update_error_msg()
+        # if serial:
+        #     ipap = SerialIcePAP(dst, 0)
+        # else:
+        #     if dst.find(":") >= 0:
+        #         aux = dst.split(':')
+        #         host = aux[0]
+        #         port = aux[1]
+        #     else:
+        #         host = dst
+        #         port = "5000"
+        #
+        #     ipap = EthIcePAP(host, port)
+        #
+        # addr = addr.replace("NONE", "")
+        # options = options.replace("NONE", "")
+        # ipap.connect()
+        #
+        # if filename != '':
+        #     save = options == 'SAVE'
+        #     self.sendFirmware(ipap, filename, logger, save=save)
+        # else:
+        #     # NO POSSIBILITY TO 'SAVE OR SL' if no filename
+        #     options = ''
+        #
+        # logger.addToLog("Setting MODE PROG")
+        # cmd = "#MODE PROG"
+        # logger.addToLog(cmd)
+        # ans = ipap.sendWriteReadCommand(cmd)
+        # logger.addToLog(ans)
+        #
+        # logger.addToLog("Configuring connection: "+addr+","+options)
+        #
+        # cmd = "PROG %s %s" % (addr, options)
+        # logger.addToLog(cmd)
+        # ipap.sendWriteCommand(cmd, prepend_ack=False)
+        #
+        # shouldwait = True
+        # while shouldwait:
+        #     p = ipap.getProgressStatus()
+        #     if p == 'DONE':
+        #         shouldwait = False
+        #     elif isinstance(p, int):
+        #         logger.addToLog('Programming %d %%' % p)
+        #         time.sleep(5)
+        #
+        # logger.addToLog("Setting MODE OPER")
+        # cmd = "#MODE OPER"
+        # logger.addToLog(cmd)
+        # ans = ipap.sendWriteReadCommand(cmd)
+        # logger.addToLog(ans)
+        #
+        # logger.addToLog('SHOULD BE ONLY IF %s IS ALL' % addr)
+        # logger.addToLog('Wait while rebooting... (25-30) secs')
+        # cmd = '#REBOOT'
+        # logger.addToLog(cmd)
+        # ans = ipap.sendWriteReadCommand(cmd)
+        # logger.addToLog(ans)
+        #
+        # # WE SHOULD WAIT UNTIL CONNECTION IS LOST
+        # secs = 0
+        # for i in range(10):
+        #     time.sleep(1)
+        #     secs += 1
+        #     if (secs % 5) == 0:
+        #         logger.addToLog('Waiting... (%2d secs).' % secs)
+        # ipap.disconnect()
+        #
+        # # WE SHOULD WAIT UNTIL ICEPAP IS RECONNECTED
+        # while not ipap.connected:
+        #     time.sleep(1)
+        #     secs += 1
+        #     if (secs % 5) == 0:
+        #         logger.addToLog('Waiting... (%2d secs).' % secs)
+        #
+        # cmd = '0:?VER INFO'
+        # logger.addToLog(cmd)
+        # ans = ipap.sendWriteReadCommand(cmd)
+        # logger.addToLog(ans)
+        # logger.addToLog('\n\nProgramming sequence done!')
+
+    def testConnection(self, serial, dst):
+        try:
+            if serial:
+                # TODO: Implement the serial communication
+                raise NotImplementedError('The serial communication is not '
+                                          'implement yet. Sorry for the '
+                                          'inconveniences')
             if dst.find(":") >= 0:
                 aux = dst.split(':')
                 host = aux[0]
@@ -635,92 +729,11 @@ class IcepapController(Singleton):
             else:
                 host = dst
                 port = "5000"
+            ipap = EthIcePAPController(host, port)
 
-            ipap = EthIcePAP(host, port)
-
-        addr = addr.replace("NONE", "")
-        options = options.replace("NONE", "")
-        ipap.connect()
-
-        if filename != '':
-            save = options == 'SAVE'
-            self.sendFirmware(ipap, filename, logger, save=save)
-        else:
-            # NO POSSIBILITY TO 'SAVE OR SL' if no filename
-            options = ''
-
-        logger.addToLog("Setting MODE PROG")
-        cmd = "#MODE PROG"
-        logger.addToLog(cmd)
-        ans = ipap.sendWriteReadCommand(cmd)
-        logger.addToLog(ans)
-
-        logger.addToLog("Configuring connection: "+addr+","+options)
-
-        cmd = "PROG %s %s" % (addr, options)
-        logger.addToLog(cmd)
-        ipap.sendWriteCommand(cmd, prepend_ack=False)
-
-        shouldwait = True
-        while shouldwait:
-            p = ipap.getProgressStatus()
-            if p == 'DONE':
-                shouldwait = False
-            elif isinstance(p, int):
-                logger.addToLog('Programming %d %%' % p)
-                time.sleep(5)
-
-        logger.addToLog("Setting MODE OPER")
-        cmd = "#MODE OPER"
-        logger.addToLog(cmd)
-        ans = ipap.sendWriteReadCommand(cmd)
-        logger.addToLog(ans)
-
-        logger.addToLog('SHOULD BE ONLY IF %s IS ALL' % addr)
-        logger.addToLog('Wait while rebooting... (25-30) secs')
-        cmd = '#REBOOT'
-        logger.addToLog(cmd)
-        ans = ipap.sendWriteReadCommand(cmd)
-        logger.addToLog(ans)
-
-        # WE SHOULD WAIT UNTIL CONNECTION IS LOST
-        secs = 0
-        for i in range(10):
-            time.sleep(1)
-            secs += 1
-            if (secs % 5) == 0:
-                logger.addToLog('Waiting... (%2d secs).' % secs)
-        ipap.disconnect()
-
-        # WE SHOULD WAIT UNTIL ICEPAP IS RECONNECTED
-        while not ipap.connected:
-            time.sleep(1)
-            secs += 1
-            if (secs % 5) == 0:
-                logger.addToLog('Waiting... (%2d secs).' % secs)
-
-        cmd = '0:?VER INFO'
-        logger.addToLog(cmd)
-        ans = ipap.sendWriteReadCommand(cmd)
-        logger.addToLog(ans)
-        logger.addToLog('\n\nProgramming sequence done!')
-
-    def testConnection(self, serial, dst):
-        try:
-            if serial:
-                ipap = SerialIcePAP(dst, 0)
-            else:
-                if dst.find(":") >= 0:
-                    aux = dst.split(':')
-                    host = aux[0]
-                    port = aux[1]
-                else:
-                    host = dst
-                    port = "5000"
-                ipap = EthIcePAP(host, port)
-            ipap.connect()
-            ipap.getSystemVersion()
-            print "testing connection"
+            msg = 'System {0} version: {ver[0]}'.format(
+                host, ver=ipap.ver.system)
+            print(msg)
             ipap.disconnect()
             return True
         except Exception:

--- a/icepapCMS/lib_icepapcms/icepapcontroller.py
+++ b/icepapCMS/lib_icepapcms/icepapcontroller.py
@@ -554,36 +554,37 @@ class IcepapController(Singleton):
             return -1
 
     def moveDriver(self, icepap_name, driver_addr, steps):
-
-        if self.iPaps[icepap_name].getMode(driver_addr) == IcepapMode.CONFIG:
+        axis = self.iPaps[icepap_name][driver_addr]
+        if Mode.CONFIG in axis.mode:
             # CMOVE ONLY ALLOWS ABSOLUTE POSITIONS, IT SHOULD BE CALCULATED
             # self.iPaps[icepap_name].cmove(driver_addr, steps)
-            pos = self.iPaps[icepap_name].getPosition(driver_addr)
-            new_pos = int(pos) + int(steps)
-            self.iPaps[icepap_name].cmove(driver_addr, new_pos)
+            new_pos = axis.pos + int(steps)
+            axis.cmove(new_pos)
         else:
-            self.iPaps[icepap_name].rmove(driver_addr, steps)
+            axis.rmove(steps)
 
     def moveDriverAbsolute(self, icepap_name, driver_addr, pos):
-        if self.iPaps[icepap_name].getMode(driver_addr) == IcepapMode.CONFIG:
-            self.iPaps[icepap_name].cmove(driver_addr, pos)
+        axis = self.iPaps[icepap_name][driver_addr]
+        if Mode.CONFIG in axis.mode:
+            axis.cmove(pos)
         else:
-            self.iPaps[icepap_name].move(driver_addr, pos)
+            axis.move(pos)
 
     def stopDriver(self, icepap_name, driver_addr):
-        self.iPaps[icepap_name].stop(driver_addr)
+        self.iPaps[icepap_name][driver_addr].stop()
 
     def abortDriver(self, icepap_name, driver_addr):
-        self.iPaps[icepap_name].abort(driver_addr)
+        self.iPaps[icepap_name][driver_addr].abort()
 
     def blinkDriver(self, icepap_name, driver_addr, secs):
-        self.iPaps[icepap_name].blink(driver_addr, secs)
+        self.iPaps[icepap_name][driver_addr].blink(secs)
 
     def jogDriver(self, icepap_name, driver_addr, speed):
-        if self.iPaps[icepap_name].getMode(driver_addr) != IcepapMode.CONFIG:
-            self.iPaps[icepap_name].jog(driver_addr, speed)
+        axis =self.iPaps[icepap_name][driver_addr]
+        if Mode.CONFIG not in axis.mode:
+            self.iPaps[icepap_name][driver_addr].jog(speed)
         else:
-            self.iPaps[icepap_name].cjog(driver_addr, speed)
+            self.iPaps[icepap_name][driver_addr].cjog(speed)
 
     def enableDriver(self, icepap_name, driver_addr):
         self.iPaps[icepap_name].enable(driver_addr)

--- a/icepapCMS/lib_icepapcms/icepapcontroller.py
+++ b/icepapCMS/lib_icepapcms/icepapcontroller.py
@@ -587,15 +587,14 @@ class IcepapController(Singleton):
             self.iPaps[icepap_name][driver_addr].cjog(speed)
 
     def enableDriver(self, icepap_name, driver_addr):
-        self.iPaps[icepap_name].enable(driver_addr)
+        self.iPaps[icepap_name][driver_addr].power = True
 
     def disableDriver(self, icepap_name, driver_addr):
-        self.iPaps[icepap_name].disable(driver_addr)
+        self.iPaps[icepap_name][driver_addr].power = False
 
     def checkIcepapStatus(self, icepap_name):
-        if icepap_name in self.iPaps and not self.iPaps[icepap_name].connected:
-            return False
-        if icepap_name not in self.iPaps:
+        if icepap_name not in self.iPaps \
+                or not self.iPaps[icepap_name].connected:
             return False
         return True
 

--- a/icepapCMS/lib_icepapcms/icepapdriver.py
+++ b/icepapCMS/lib_icepapcms/icepapdriver.py
@@ -21,7 +21,7 @@ import os
 import time
 from datetime import datetime
 import socket
-from pyIcePAP import IcepapMode
+from pyIcePAP import Mode
 
 
 class IcepapDriver(Storm):
@@ -92,7 +92,7 @@ class IcepapDriver(Storm):
             host = socket.gethostname()
             signature = user+"@"+host+"_"+datetime.now().strftime('%Y/%m/%d_%H:%M:%S')
             IcepapController().signDriverConfiguration(self.icepapsystem_name, self.addr, signature)
-            self.mode = unicode(IcepapMode.OPER)
+            self.mode = unicode(Mode.OPER)
             db = StormManager()
             db.commitTransaction()
             self.current_cfg.name = unicode(time.ctime())

--- a/icepapCMS/lib_icepapcms/icepapzodb/icepapdriver.py
+++ b/icepapCMS/lib_icepapcms/icepapzodb/icepapdriver.py
@@ -15,8 +15,8 @@ from persistent import Persistent
 from icepapdrivercfg import IcepapDriverCfg
 from conflict import Conflict
 import socket, time
-from pyIcePAP import *
 import icepapcontroller
+from pyIcePAP import Mode
 
 class IcepapDriver(Persistent):
     def __init__(self, icepap_name, addr, cratenr, drivernr, name = None):
@@ -55,7 +55,7 @@ class IcepapDriver(Persistent):
         self.currentCfg.signConfig(signature)        
         self.startupCfg = self.currentCfg
         self.conflict = Conflict.NO_CONFLICT
-        self.mode = IcepapMode.OPER
+        self.mode = Mode.OPER
         self.historicCfg[(time.time())] = self.currentCfg
     
     def setStartupCfg(self):

--- a/icepapCMS/lib_icepapcms/mainmanager.py
+++ b/icepapCMS/lib_icepapcms/mainmanager.py
@@ -19,9 +19,8 @@ from singleton import Singleton
 #from zodbmanager import ZODBManager
 from PyQt4 import QtCore
 from PyQt4 import QtGui
-
+from pyIcePAP import Mode
 #from conflict import Conflict
-from pyIcePAP import *
 
 from ..ui_icepapcms.messagedialogs import MessageDialogs
 import sys
@@ -123,7 +122,7 @@ class MainManager(Singleton):
                 if len(driver_list) == 0:
                     MessageDialogs.showWarningMessage(None, "Scanning Icepap Warning", "The icepap system '"+icepap_name+"' has ZERO drivers.\nPlease make sure that the CAN BUS TERMINATOR is connected.")
                 return icepap_system
-            except IcePAPException,ie:
+            except Exception as ie:
                 MessageDialogs.showErrorMessage(None, "Scanning Icepap Error", "Could not scan the '"+icepap_name+"' Icepap System.\nPlease make sure that the system '"+(icepap_name)+"' is in your subnetwork.\nException:\n\t"+str(ie))
             except Exception,e:
                 print "Unknown exception:",e
@@ -177,7 +176,7 @@ class MainManager(Singleton):
         try:
             self._ctrl_icepap.closeConnection(icepap_system.name)
             self._db.commitTransaction()
-        except IcePAPException,error:
+        except Exception as error:
             MessageDialogs.showErrorMessage(self._form, "Stop Icepap error", "%s Connection error:%s" % (icepap_name,error.msg))
         except:
             print "mainmanager:stopIcepap:Unexpected error:", sys.exc_info()   
@@ -194,7 +193,7 @@ class MainManager(Singleton):
                 conflictsList = icepap_system.compareDriverList(driver_list)
             else:
                 conflictsList.append([Conflict.NO_CONNECTION, icepap_system, 0])
-        except IcePAPException,error:
+        except Exception as error:
             MessageDialogs.showErrorMessage(None, "Scanning Icepap Error", "Could not scan the '"+icepap_name+"' Icepap System.\nPlease make sure that the system '"+(icepap_name)+"' is in your subnetwork.\nException:"+str(error))
         except:
             print "mainmanager:scanIcepap:Unexpected error:", sys.exc_info()
@@ -280,7 +279,7 @@ class MainManager(Singleton):
         for icepap_system in self.IcepapSystemList.values():
             """ TO-DO STORM review"""
             for driver in icepap_system.getDrivers():
-                if driver.mode == IcepapMode.CONFIG:
+                if driver.mode == Mode.CONFIG:
                     signList.append(driver)
         return signList
          
@@ -311,7 +310,7 @@ class MainManager(Singleton):
                 return (-1,False,-1)
             status = self._ctrl_icepap.getDriverStatus(icepap_name, addr)
             return status
-        except IcePAPException, error:
+        except Exception as  error:
             MessageDialogs.showErrorMessage(self._form, "GetDriverStatus Icepap error", "%s,%d Connection timeout" % (icepap_name,addr))
             self._form.refreshTree()
             return (-1, False, -1) 
@@ -327,7 +326,7 @@ class MainManager(Singleton):
             Returns [status register, power state, [position register value, encoder register value]"""
         try:
             return self._ctrl_icepap.getDriverTestStatus(icepap_name, addr, pos_sel, enc_sel)
-        except IcePAPException, error:
+        except Exception as  error:
             MessageDialogs.showErrorMessage(self._form, "GetDriverTestStatus Icepap error", "%s Connection error:%s" % (icepap_name,error.msg))
             self._form.refreshTree() 
             return (-1,-1, [-1,-1])        
@@ -340,7 +339,7 @@ class MainManager(Singleton):
         """ Gets from adriver the values of the parameters in par_list """
         try:
             return self._ctrl_icepap.readIcepapParameters(icepap_name, addr, par_list)
-        except IcePAPException, error:
+        except Exception as  error:
             MessageDialogs.showErrorMessage(self._form, "ReadIcepapParamenters Icepap error", "%s Connection error:%s" % (icepap_name,error.msg))
         except:
             print "mainmanager:readIcepapParameters:Unexpected error:", sys.exc_info()
@@ -379,7 +378,7 @@ class MainManager(Singleton):
     def moveDriver(self, icepap_name, addr, steps):
         try:
             self._ctrl_icepap.moveDriver(icepap_name, addr, steps)
-        except IcePAPException,error:
+        except Exception as error:
             MessageDialogs.showErrorMessage(self._form, "MoveDriver Icepap error", "%s Connection error:%s" % (icepap_name,error.msg))
         except:
             print "mainmanager:moveDriver:Unexpected error:", sys.exc_info()
@@ -388,7 +387,7 @@ class MainManager(Singleton):
     def moveDriverAbsolute(self, icepap_name, addr, position):
         try:
             self._ctrl_icepap.moveDriverAbsolute(icepap_name, addr, position)
-        except IcePAPException,error:
+        except Exception as error:
             MessageDialogs.showErrorMessage(self._form, "MoveDriverAbsolute Icepap error", "%s Connection error:%s" % (icepap_name,error.msg))
         except:
             print "mainmanager:moveDriverAbsolute:Unexpected error:", sys.exc_info()
@@ -423,7 +422,7 @@ class MainManager(Singleton):
             #self._form.checkIcepapConnection()
             return False
         else:
-            icepap_driver.mode = unicode(IcepapMode.CONFIG)
+            icepap_driver.mode = unicode(Mode.CONFIG)
             icepap_driver.addConfiguration(new_cfg)
             return True
 

--- a/icepapCMS/ui_icepapcms/icepap_treemodel.py
+++ b/icepapCMS/ui_icepapcms/icepap_treemodel.py
@@ -13,7 +13,8 @@
 
 import sys
 from PyQt4 import QtCore, QtGui
-from ..lib_icepapcms import IcepapSystem, IcepapDriver, Conflict, IcepapMode
+from ..lib_icepapcms import IcepapSystem, IcepapDriver, Conflict
+from pyIcePAP import Mode
 
 
 
@@ -243,7 +244,7 @@ class TreeItem:
                 self.role = IcepapTreeModel.DRIVER_WARNING
             elif self.itemData.conflict == Conflict.DRIVER_MOVED:
                 self.role = IcepapTreeModel.DRIVER_MOVED
-            elif self.itemData.mode == IcepapMode.CONFIG:
+            elif self.itemData.mode == Mode.CONFIG:
                 self.role = IcepapTreeModel.DRIVER_CFG
         return self.role
         

--- a/icepapCMS/ui_icepapcms/icepapcms.py
+++ b/icepapCMS/ui_icepapcms/icepapcms.py
@@ -514,9 +514,9 @@ class IcepapCMS(QtGui.QMainWindow):
         driver = item.itemData
         system = driver.icepapsystem_name
         addr = driver.addr
-        expert = self._manager._ctrl_icepap.iPaps[system].isExpertFlagSet(addr)
+        expert = self._manager._ctrl_icepap.isExpertFlagSet(system, addr)
         expertFlag = (expert == 'YES')
-        message = "%s.%d: Set DataBase values?" % (system,addr)
+        message = "%s.%d: Set DataBase values?" % (system, addr)
         if expertFlag:
             message = "%s.%d: Set Driver Values?\n" %(system,addr)
             message = message + "FOUND CONFIG WITH EXPERT = YES"
@@ -653,7 +653,7 @@ class IcepapCMS(QtGui.QMainWindow):
                 driver_item.setText(driver_value)
                 table.setItem(row, 1, driver_item)
         
-        expert = self._manager._ctrl_icepap.iPaps[system].isExpertFlagSet(addr)
+        expert = self._manager._ctrl_icepap.isExpertFlagSet(system, addr)
         expertFlag = (expert == 'YES')
         dialog = DialogNewDriver(self, more_info_dialog, expertFlag)
         dialog.exec_()

--- a/icepapCMS/ui_icepapcms/icepapdriver_widget/icepapdriverwidget.py
+++ b/icepapCMS/ui_icepapcms/icepapdriver_widget/icepapdriverwidget.py
@@ -16,7 +16,8 @@ from .ui_icepapdriverwidget import Ui_IcePapDriverWidget
 from .ui_icepapdriverwidgetsmall import Ui_IcePapDriverWidgetSmall
 from ...ui_icepapcms.qrc_icepapcms import *
 from ...ui_icepapcms.Led import Led
-from ...lib_icepapcms import MainManager, IcepapDriver, Conflict, IcepapMode, IcepapStatus
+from ...lib_icepapcms import MainManager, IcepapDriver, Conflict
+from pyIcePAP import Mode, State
 
 class IcePapDriverWidget(QtGui.QWidget):
     def __init__(self, parent=None, BigSize = True):
@@ -108,7 +109,7 @@ class IcePapDriverWidget(QtGui.QWidget):
             self.setPaletteColor(self.ui.frame,self.colorerror ,Qt.Qt.black)
         elif self._driver.conflict == Conflict.DRIVER_CHANGED:
             self.setPaletteColor(self.ui.frame,self.colorwarning,Qt.Qt.black)
-        elif self._driver.mode == IcepapMode.CONFIG:
+        elif self._driver.mode == Mode.CONFIG:
             self.setPaletteColor(self.ui.frame,self.colorconfig,Qt.Qt.black)
         else:
             self.setPaletteColor(self.ui.frame,self.colorok,Qt.Qt.black)
@@ -119,10 +120,11 @@ class IcePapDriverWidget(QtGui.QWidget):
             self.ui.ledStatus.changeColor(Led.RED)
             self.ui.ledStatus.on()
             return
-        
-        disabled = IcepapStatus.isDisabled(status)
-        ready = IcepapStatus.isReady(status)
-        mode = IcepapStatus.getMode(status)
+
+        axis_state = State(status)
+        disabled = axis_state.is_disabled()
+        ready = axis_state.is_ready()
+        mode = axis_state.get_mode_code()
         if self.status <> disabled or self.mode <> mode or self.power <> power or self.ready <> ready:
             if disabled == 0:
                 if power:
@@ -161,8 +163,8 @@ class IcePapDriverWidget(QtGui.QWidget):
         self.ready = ready   
         self.power = power
 
-        lower = IcepapStatus.getLimitNegative(status) 
-        upper = IcepapStatus.getLimitPositive(status)
+        lower = axis_state.is_limit_negative()
+        upper = axis_state.is_limit_positive()
         if lower:
             self.ui.ledLimitNeg.on()
         else:


### PR DESCRIPTION
This PR remove the deprecation warning on IcepapCMS generated by using the pyIcePAP API 2.0. It solves #4. 

The console is not migrated yet. 