### PR TITLE
Fixed bug in getDriverConfiguration() when axis name is not set.

### DIFF
--- a/icepapCMS/lib_icepapcms/icepapcontroller.py
+++ b/icepapCMS/lib_icepapcms/icepapcontroller.py
@@ -178,7 +178,7 @@ class IcepapController(Singleton):
         # THE DSP'S ONE.
         axis_name = axis.name
         # FIX NON-ASCII CHARS ISSUE IN NAME:
-        if axis_name and not all(ord(c) < 128 for c in axis_name):
+        if axis_name is not None and not all(ord(c) < 128 for c in axis_name):
             axis_name = repr(axis.name)
         driver_cfg.setParameter(unicode("VER"), axis.ver.driver[0])
         driver_cfg.setParameter(unicode("ID"), axis.id)

--- a/icepapCMS/lib_icepapcms/icepapcontroller.py
+++ b/icepapCMS/lib_icepapcms/icepapcontroller.py
@@ -178,7 +178,7 @@ class IcepapController(Singleton):
         # THE DSP'S ONE.
         axis_name = axis.name
         # FIX NON-ASCII CHARS ISSUE IN NAME:
-        if not all(ord(c) < 128 for c in axis_name):
+        if axis_name and not all(ord(c) < 128 for c in axis_name):
             axis_name = repr(axis.name)
         driver_cfg.setParameter(unicode("VER"), axis.ver.driver[0])
         driver_cfg.setParameter(unicode("ID"), axis.id)


### PR DESCRIPTION
@rhomspuron 
Prevented attempt to iterate over characters in axis name when it is set to None.