### PR TITLE
Icepapcontroller active status reads active attribute

### DIFF
--- a/icepapCMS/lib_icepapcms/icepapcontroller.py
+++ b/icepapCMS/lib_icepapcms/icepapcontroller.py
@@ -394,7 +394,7 @@ class IcepapController(Singleton):
 
     def getDriverActiveStatus(self, icepap_name, driver_addr):
         try:
-            active = self.iPaps[icepap_name][driver_addr]
+            active = self.iPaps[icepap_name][driver_addr].active
             if active:
                 return 'YES'
             else:


### PR DESCRIPTION
Fix for issue #22 

Change   `getDriverActiveStatus` to query `active` axis attribute. If the axis is not active, `Test and status` widget does not query icepap infos.