### PR TITLE
Allow placing a system wide config in /etc/icepapcms (linux) or %systemdrive%/ProgramData/IcePAP (windows)

### DIFF
--- a/icepapcms/__main__.py
+++ b/icepapcms/__main__.py
@@ -23,10 +23,14 @@ def get_parser():
     # parser.add_argument(
     #     "--ldap", action="store_true", dest="ldap",
     #     help="Force LDAP login to get username. False by default")
-    parser.add_argument('-c', '--config-path',
-                        action='store', type=str, dest='config_path', 
+    parser.add_argument('-c', '--config-file',
+                        action='store', type=str, dest='config_file', 
                         help='Path to configuration file. '
-                             'Defaults to .icepapcms/icepapcms.conf or /etc/icepapcms/icepapcms.conf')
+                             'Defaults to trying first /etc/icepapcms/icepapcms.conf, then ~/.icepapcms/icepapcms.conf')
+    parser.add_argument('-u', '--user',
+                        action='store_true', dest='user_config', 
+                        help='Ignore system-wide config, only use config in user home folder, '
+                             ' ~/.icepapcms/icepapcms.conf')
     parser.add_argument("--debug-level", dest='debug_level', type=str,
                         help='Logging level used:[DEBUG, INFO, WARNING, '
                              'ERROR, CRITICAL]', default='WARNING')

--- a/icepapcms/__main__.py
+++ b/icepapcms/__main__.py
@@ -23,6 +23,10 @@ def get_parser():
     # parser.add_argument(
     #     "--ldap", action="store_true", dest="ldap",
     #     help="Force LDAP login to get username. False by default")
+    parser.add_argument('-c', '--config-path',
+                        action='store', type=str, dest='config_path', 
+                        help='Path to configuration file. '
+                             'Defaults to .icepapcms/icepapcms.conf or /etc/icepapcms/icepapcms.conf')
     parser.add_argument("--debug-level", dest='debug_level', type=str,
                         help='Logging level used:[DEBUG, INFO, WARNING, '
                              'ERROR, CRITICAL]', default='WARNING')
@@ -46,7 +50,8 @@ def configure_logging():
     log_console = logging.StreamHandler()
     log_console.setFormatter(logging.Formatter(log_format))
 
-    log_filename = os.path.join(config_manager.log_folder, 'log.txt')
+    log_filename = os.path.join(config_manager.base_folder, config_manager.log_folder, 'log.txt')
+    print("log name", log_filename)
     log_file = logging.handlers.RotatingFileHandler(
         log_filename, maxBytes=10000000, backupCount=5)
     log_file.setFormatter(logging.Formatter(log_format))
@@ -72,9 +77,9 @@ def configure_logging():
 
 
 def main():
-    config_manager = ConfigManager()
+    
     args = get_parser().parse_args()
-
+    config_manager = ConfigManager(args)
     config_manager._options = args
     listener = configure_logging()
 

--- a/icepapcms/__main__.py
+++ b/icepapcms/__main__.py
@@ -55,7 +55,7 @@ def configure_logging():
     log_console.setFormatter(logging.Formatter(log_format))
 
     log_filename = os.path.join(config_manager.log_folder, 'log.txt')
-    print("log name", log_filename)
+    print("Writing logs to:", log_filename)
     log_file = logging.handlers.RotatingFileHandler(
         log_filename, maxBytes=10000000, backupCount=5)
     log_file.setFormatter(logging.Formatter(log_format))

--- a/icepapcms/__main__.py
+++ b/icepapcms/__main__.py
@@ -54,7 +54,7 @@ def configure_logging():
     log_console = logging.StreamHandler()
     log_console.setFormatter(logging.Formatter(log_format))
 
-    log_filename = os.path.join(config_manager.base_folder, config_manager.log_folder, 'log.txt')
+    log_filename = os.path.join(config_manager.log_folder, 'log.txt')
     print("log name", log_filename)
     log_file = logging.handlers.RotatingFileHandler(
         log_filename, maxBytes=10000000, backupCount=5)

--- a/icepapcms/__main__.py
+++ b/icepapcms/__main__.py
@@ -26,11 +26,13 @@ def get_parser():
     parser.add_argument('-c', '--config-file',
                         action='store', type=str, dest='config_file', 
                         help='Path to configuration file. '
-                             'Defaults to trying first /etc/icepapcms/icepapcms.conf, then ~/.icepapcms/icepapcms.conf')
+                             'Defaults to trying first /etc/icepapcms/icepapcms.conf,'
+                             ' then ~/.icepapcms/configs/icepapcms.conf')
     parser.add_argument('-u', '--user',
                         action='store_true', dest='user_config', 
-                        help='Ignore system-wide config, only use config in user home folder, '
-                             ' ~/.icepapcms/icepapcms.conf')
+                        help='Ignore system-wide config.'
+                             ' Only use config in user home directory, '
+                             ' ~/.icepapcms/configs/icepapcms.conf')
     parser.add_argument("--debug-level", dest='debug_level', type=str,
                         help='Logging level used:[DEBUG, INFO, WARNING, '
                              'ERROR, CRITICAL]', default='WARNING')

--- a/icepapcms/__main__.py
+++ b/icepapcms/__main__.py
@@ -23,11 +23,16 @@ def get_parser():
     # parser.add_argument(
     #     "--ldap", action="store_true", dest="ldap",
     #     help="Force LDAP login to get username. False by default")
+    if os.name == "nt":
+        system_config_path = os.path.expandvars("%systemdrive%/ProgramData/IcePAP")
+    else:
+        system_config_path = "/etc/icepap"
     parser.add_argument('-c', '--config-file',
                         action='store', type=str, dest='config_file', 
                         help='Path to configuration file. '
-                             'Defaults to trying first /etc/icepapcms/icepapcms.conf,'
-                             ' then ~/.icepapcms/configs/icepapcms.conf')
+                             'Defaults to trying first {}/icepapcms.conf,'
+                             ' then ~/.icepapcms/configs/icepapcms.conf'
+                             .format(system_config_path))
     parser.add_argument('-u', '--user',
                         action='store_true', dest='user_config', 
                         help='Ignore system-wide config.'

--- a/icepapcms/db/creates_sqlite.sql
+++ b/icepapcms/db/creates_sqlite.sql
@@ -72,4 +72,3 @@ CREATE INDEX CfgParameter_FKIndex1_cfgparam on cfgparameter (cfg_id);
 CREATE INDEX IcepapDriver_FKIndex1_icepapdr on icepapdriver (icepapsystem_name);
 CREATE INDEX IcepapDriverCfg_FKIndex1_icepa on icepapdrivercfg (driver_addr, icepapsystem_name);
 CREATE INDEX FKLocation_icepapsystem on icepapsystem (location_name);
-

--- a/icepapcms/gui/dialogpreferences.py
+++ b/icepapcms/gui/dialogpreferences.py
@@ -59,7 +59,7 @@ class DialogPreferences(QtWidgets.QDialog):
         self._config = ConfigManager()
         self.fillConfig()
         self.ui.listWidget.item(0).setSelected(True)
-        self.setWindowTitle("Preferences (%s)" % self._config.base_folder)
+        self.setWindowTitle("Preferences (%s)" % self._config.config_filename)
         """ check imports for dbs to disable errors """
 
     @loggingInfo

--- a/icepapcms/gui/dialogpreferences.py
+++ b/icepapcms/gui/dialogpreferences.py
@@ -17,6 +17,7 @@ import logging
 from ..lib import ConfigManager
 from .messagedialogs import MessageDialogs
 from ..helpers import loggingInfo
+import os
 
 # TODO Change to properties
 MYSQL_PORT = 3306
@@ -58,16 +59,30 @@ class DialogPreferences(QtWidgets.QDialog):
         self._config = ConfigManager()
         self.fillConfig()
         self.ui.listWidget.item(0).setSelected(True)
+        self.setWindowTitle("Preferences (%s)" % self._config.base_folder)
         """ check imports for dbs to disable errors """
 
     @loggingInfo
     def closeButton_on_click(self):
-        if self.checkPreferences():
-            self._config.saveConfig()
-            self.close()
+        print("aaaaaa")
+        if not os.path.exists(self._config.config_filename):
+            print("bbbbbb")
+            if os.access(self._config.base_folder, os.W_OK):
+                print("Creating new config file...")
+                open(self._config.config_filename, 'a').close()
+        if os.access(self._config.config_filename, os.W_OK) :
+            print("ddddd")
+            if self.checkPreferences():
+                print("eeeee", self._config.config_filename)
+                self._config.saveConfig()
+                self.close()
+            else:
+                MessageDialogs.showWarningMessage(self, "Preferences", 
+                    "Check configuration parameters")
         else:
-            MessageDialogs.showWarningMessage(
-                self, "Preferences", "Check configuration parameters")
+            MessageDialogs.showWarningMessage(self, "Preferences", 
+                "You must run IcePAPCMS as superuser to change the configuration"
+                " parameters, or use a local config file.")
 
     @loggingInfo
     def listWidget_on_click(self, item):

--- a/icepapcms/gui/dialogpreferences.py
+++ b/icepapcms/gui/dialogpreferences.py
@@ -46,8 +46,6 @@ class DialogPreferences(QtWidgets.QDialog):
         self.ui.btnLogBrowser.clicked.connect(self.btnLogBrowse_on_click)
         self.ui.btnFirmwareBrowser.clicked.connect(
             self.btnFirmwareBrowse_on_click)
-        self.ui.btnConfigsBrowser.clicked.connect(
-            self.btnConfigsBrowse_on_click)
         self.ui.btnTemplatesBrowser.clicked.connect(
             self.btnTemplatesBrowse_on_click)
         self.ui.closeButton.clicked.connect(self.closeButton_on_click)
@@ -59,7 +57,6 @@ class DialogPreferences(QtWidgets.QDialog):
         self._config = ConfigManager()
         self.fillConfig()
         self.ui.listWidget.item(0).setSelected(True)
-        self.setWindowTitle("Preferences (%s)" % self._config.config_filename)
         """ check imports for dbs to disable errors """
 
     @loggingInfo
@@ -139,17 +136,6 @@ class DialogPreferences(QtWidgets.QDialog):
             return
         folder = str(fn)
         self.ui.txtFirmwareFolder.setText(folder)
-
-    @loggingInfo
-    def btnConfigsBrowse_on_click(self):
-        current_folder = \
-            self._config.config[self._config.icepap]["configs_folder"]
-        fn = QtWidgets.QFileDialog.getExistingDirectory(
-            self, "Open Configs Folder", current_folder)
-        if fn == '':
-            return
-        folder = str(fn)
-        self.ui.txtConfigsFolder.setText(folder)
 
     @loggingInfo
     def btnTemplatesBrowse_on_click(self):
@@ -234,7 +220,7 @@ class DialogPreferences(QtWidgets.QDialog):
         debug_level = config["debug_level"]
         log_folder = config["log_folder"]
         firmware_folder = config["firmware_folder"]
-        configs_folder = config["configs_folder"]
+        configs_folder = self._config.configs_folder
         templates_folder = config["templates_folder"]
         snapshots_folder = config['snapshots_folder']
 
@@ -282,7 +268,6 @@ class DialogPreferences(QtWidgets.QDialog):
             config_ipap["debug_level"] = int(self.ui.sbDebugLevel.value())
             config_ipap["log_folder"] = self.ui.txtLogFolder.text()
             config_ipap["firmware_folder"] = self.ui.txtFirmwareFolder.text()
-            config_ipap["configs_folder"] = self.ui.txtConfigsFolder.text()
             config_ipap["templates_folder"] = self.ui.txtTemplatesFolder.text()
             config_ipap["snapshots_folder"] = self.ui.txtSnapshotsFolder.text()
 

--- a/icepapcms/gui/dialogpreferences.py
+++ b/icepapcms/gui/dialogpreferences.py
@@ -170,8 +170,7 @@ class DialogPreferences(QtWidgets.QDialog):
             except ImportError:
                 ok_sqlite = False
                 module_errors = module_errors + \
-                    "Failed to import Sqlite Modules: pysqlite2, sqlite3 " \
-                    "modules\n"
+                    "Sqlite storage not available, requires one of the modules 'pysqlite2' or 'sqlite3'\n"
         self.ui.rbsqlite.setEnabled(ok_sqlite)
 
         postgres = True
@@ -180,7 +179,7 @@ class DialogPreferences(QtWidgets.QDialog):
             import psycopg2.extensions
         except BaseException:
             postgres = False
-            module_errors += "Failed to import Postgres modules:psycopg2\n"
+            module_errors += "Postgres storage not available, requires module 'psycopg2'\n"
         self.ui.rbpostgres.setEnabled(postgres)
 
         mysql = True
@@ -188,7 +187,7 @@ class DialogPreferences(QtWidgets.QDialog):
             import MySQLdb
             import MySQLdb.converters
         except BaseException:
-            module_errors += "Failed to import MySQL modules: MySQLdb\n"
+            module_errors += "MySQL storage not available, requires module 'MySQLdb'\n"
             mysql = False
         if module_errors != "":
             module_errors += "Check IcepapCMS user manual to solve these " \

--- a/icepapcms/gui/dialogpreferences.py
+++ b/icepapcms/gui/dialogpreferences.py
@@ -78,8 +78,8 @@ class DialogPreferences(QtWidgets.QDialog):
                     "Check configuration parameters")
         else:
             MessageDialogs.showWarningMessage(self, "Preferences", 
-                "You must run IcePAPCMS as superuser to change the configuration"
-                " parameters, or use a local config file.")
+                "You must run IcePAPCMS as superuser to change"
+                " the configuration parameters.")
 
     @loggingInfo
     def listWidget_on_click(self, item):

--- a/icepapcms/gui/dialogpreferences.py
+++ b/icepapcms/gui/dialogpreferences.py
@@ -68,12 +68,12 @@ class DialogPreferences(QtWidgets.QDialog):
         if not os.path.exists(self._config.config_filename):
             print("bbbbbb")
             if os.access(self._config.base_folder, os.W_OK):
-                print("Creating new config file...")
+                print("Creating new config file:", self._config.config_filename)
                 open(self._config.config_filename, 'a').close()
         if os.access(self._config.config_filename, os.W_OK) :
             print("ddddd")
             if self.checkPreferences():
-                print("eeeee", self._config.config_filename)
+                print("Writing config to:", self._config.config_filename)
                 self._config.saveConfig()
                 self.close()
             else:

--- a/icepapcms/gui/dialogpreferences.py
+++ b/icepapcms/gui/dialogpreferences.py
@@ -64,14 +64,11 @@ class DialogPreferences(QtWidgets.QDialog):
 
     @loggingInfo
     def closeButton_on_click(self):
-        print("aaaaaa")
         if not os.path.exists(self._config.config_filename):
-            print("bbbbbb")
             if os.access(self._config.base_folder, os.W_OK):
                 print("Creating new config file:", self._config.config_filename)
                 open(self._config.config_filename, 'a').close()
         if os.access(self._config.config_filename, os.W_OK) :
-            print("ddddd")
             if self.checkPreferences():
                 print("Writing config to:", self._config.config_filename)
                 self._config.saveConfig()

--- a/icepapcms/gui/dialogpreferences.py
+++ b/icepapcms/gui/dialogpreferences.py
@@ -65,10 +65,10 @@ class DialogPreferences(QtWidgets.QDialog):
     @loggingInfo
     def closeButton_on_click(self):
         if not os.path.exists(self._config.config_filename):
-            if os.access(self._config.base_folder, os.W_OK):
+            if os.access(self._config.configs_folder, os.W_OK):
                 print("Creating new config file:", self._config.config_filename)
                 open(self._config.config_filename, 'a').close()
-        if os.access(self._config.config_filename, os.W_OK) :
+        if os.access(self._config.config_filename, os.W_OK):
             if self.checkPreferences():
                 print("Writing config to:", self._config.config_filename)
                 self._config.saveConfig()

--- a/icepapcms/gui/icepapcms.py
+++ b/icepapcms/gui/icepapcms.py
@@ -278,6 +278,9 @@ class IcepapCMS(QtWidgets.QMainWindow):
             self.contextEditIcepap)""",
             """self.menu.addAction("Delete Icepap system configuration",
             self.btnTreeRemove_on_click)""",
+            """self.menu.addSeparator()""",
+            """self.menu.addAction("Open Icepap console",
+            self.contextOpenConsole)""",
         ]
         self.menu = Qt.QMenu(self)
         font = QtGui.QFont()
@@ -286,22 +289,22 @@ class IcepapCMS(QtWidgets.QMainWindow):
         self.context_menu_item = item
         shown_actions = []
         if item.role == IcepapTreeModel.SYSTEM_OFFLINE:
-            shown_actions = [5, 8, 9, 10]
+            shown_actions = [5, 8, 9, 10, 11, 12]
         if item.role == IcepapTreeModel.DRIVER:
-            shown_actions = [6, 7, 8, 9, 10]
+            shown_actions = [6, 7, 8, 9, 10, 11, 12]
         elif item.role == IcepapTreeModel.DRIVER_CFG:
-            shown_actions = [0, 4, 6, 7, 8, 9, 10]
+            shown_actions = [0, 4, 6, 7, 8, 9, 10, 11, 12]
         elif item.role == IcepapTreeModel.DRIVER_ERROR:
-            shown_actions = [2, 4, 6, 7, 8, 9, 10]
+            shown_actions = [2, 4, 6, 7, 8, 9, 10, 11, 12]
         elif item.role == IcepapTreeModel.DRIVER_WARNING:
-            shown_actions = [1, 4, 6, 7, 8, 9, 10]
+            shown_actions = [1, 4, 6, 7, 8, 9, 10, 11, 12]
         elif item.role == IcepapTreeModel.DRIVER_NEW:
-            shown_actions = [3, 4, 6, 7, 8, 9, 10]
+            shown_actions = [3, 4, 6, 7, 8, 9, 10, 11, 12]
         elif item.role == IcepapTreeModel.SYSTEM or \
                 item.role == IcepapTreeModel.CRATE or \
                 item.role == IcepapTreeModel.SYSTEM_ERROR or \
                 item.role == IcepapTreeModel.SYSTEM_WARNING:
-            shown_actions = [6, 7, 8, 9, 10]
+            shown_actions = [6, 7, 8, 9, 10, 11, 12]
         for i in shown_actions:
             exec(actions[i])
         self.menu.popup(self.cursor().pos())
@@ -326,6 +329,17 @@ class IcepapCMS(QtWidgets.QMainWindow):
             item = self.context_menu_item
             self.editIcepap(item)
         self.context_menu_item = None
+
+    @loggingInfo
+    def contextOpenConsole(self):
+        if self.context_menu_item:
+            item = self.context_menu_item
+            icepap_system = item.getIcepapSystem()
+            addr = "%s:%s" % (icepap_system.host, icepap_system.port)
+            dlg = IcepapConsole(self, host=addr)
+            dlg.show()
+        self.context_menu_item = None
+
 
     @loggingInfo
     def contextSolveConflict(self):

--- a/icepapcms/gui/ipapconsole.py
+++ b/icepapcms/gui/ipapconsole.py
@@ -26,7 +26,7 @@ class IcepapConsole(QtWidgets.QDialog):
     log = logging.getLogger('{}.IcepapConsole'.format(__name__))
 
     @loggingInfo
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, host=None):
         QtWidgets.QDialog.__init__(self, parent, QtCore.Qt.Window)
         ui_filename = resource_filename('icepapcms.gui.ui',
                                         'ipapconsole.ui')
@@ -48,6 +48,8 @@ class IcepapConsole(QtWidgets.QDialog):
         self.ui.console.setPrompt(self.prompt)
         self.log_folder = None
         self._config = ConfigManager()
+        if host:
+            self.ui.txtHost.setText(host)
         try:
             ipap_cfg = self._config.config[self._config.icepap]
             self.debug = ipap_cfg["debug_enabled"] == str(True)

--- a/icepapcms/gui/pageipapdriver.py
+++ b/icepapcms/gui/pageipapdriver.py
@@ -152,6 +152,7 @@ class PageiPapDriver(QtWidgets.QWidget):
 
         self.setLedsOff()
         self.icepap_driver = None
+        self.temp_file = None
         self.inMotion = -1
         self.status = -1
 
@@ -1226,6 +1227,9 @@ class PageiPapDriver(QtWidgets.QWidget):
 
     @loggingInfo
     def getXmlData(self):
+        if self.icepap_driver is None:
+            # No system selected!
+            return None
         doc = getDOMImplementation().createDocument(None, "Driver", None)
         dbIcepapSystem = StormManager().getIcepapSystem(
             self.icepap_driver.icepapsystem_name)
@@ -1247,11 +1251,12 @@ class PageiPapDriver(QtWidgets.QWidget):
 
     @loggingInfo
     def doCopy(self):
-        self.temp_file = tempfile.TemporaryFile()
         data = self.getXmlData()
-        self.temp_file.write(data.toprettyxml(encoding="utf-8"))
-        self.temp_file.flush()
-        self.temp_file.seek(0)
+        if data is not None:
+            self.temp_file = tempfile.TemporaryFile()
+            self.temp_file.write(data.toprettyxml(encoding="utf-8"))
+            self.temp_file.flush()
+            self.temp_file.seek(0)
 
     @loggingInfo
     def doPaste(self):

--- a/icepapcms/gui/pageipapdriver.py
+++ b/icepapcms/gui/pageipapdriver.py
@@ -1164,7 +1164,7 @@ class PageiPapDriver(QtWidgets.QWidget):
     def doImport(self):
         filename = ""
         try:
-            folder = ConfigManager().config["icepap"]["configs_folder"]
+            folder = ConfigManager().configs_folder
             fn = QtWidgets.QFileDialog.getOpenFileName(
                 self, "Open Config File", folder, "*.xml")
             if fn[0] == '':
@@ -1207,7 +1207,7 @@ class PageiPapDriver(QtWidgets.QWidget):
 
     @loggingInfo
     def doExport(self):
-        folder = ConfigManager().config["icepap"]["configs_folder"]
+        folder = ConfigManager().configs_folder
         fn = QtWidgets.QFileDialog.getSaveFileName(
             self, "Save Config File", folder, "*.xml")
         if fn[0] == '':

--- a/icepapcms/gui/ui/dialogpreferences.ui
+++ b/icepapcms/gui/ui/dialogpreferences.ui
@@ -587,7 +587,7 @@
    <item row="1" column="0">
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="pageStorage">
       <layout class="QGridLayout">

--- a/icepapcms/gui/ui/dialogpreferences.ui
+++ b/icepapcms/gui/ui/dialogpreferences.ui
@@ -587,7 +587,7 @@
    <item row="1" column="0">
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="pageStorage">
       <layout class="QGridLayout">
@@ -996,19 +996,46 @@ p, li { white-space: pre-wrap; }
           <string>Debugging configuration</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="chkDebug">
+          <item row="7" column="3">
+           <widget class="QToolButton" name="btnTemplatesBrowser">
             <property name="text">
-             <string>Debugging enabled</string>
+             <string>...</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_5">
+          <item row="3" column="3">
+           <widget class="QToolButton" name="btnLogBrowser">
             <property name="text">
-             <string>Debug level</string>
+             <string>...</string>
             </property>
            </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Firmware folder</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Log folder</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <spacer>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>261</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
           <item row="1" column="1">
            <widget class="QSpinBox" name="sbDebugLevel">
@@ -1026,99 +1053,14 @@ p, li { white-space: pre-wrap; }
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
-           <spacer>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>261</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_6">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="chkDebug">
             <property name="text">
-             <string>Log folder</string>
+             <string>Debugging enabled</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QLineEdit" name="txtLogFolder">
-            <property name="maximumSize">
-             <size>
-              <width>1666666</width>
-              <height>16777215</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QToolButton" name="btnLogBrowser">
-            <property name="text">
-             <string>...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Firmware folder</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1" colspan="2">
-           <widget class="QLineEdit" name="txtFirmwareFolder">
-            <property name="maximumSize">
-             <size>
-              <width>1666666</width>
-              <height>16777215</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="3">
-           <widget class="QToolButton" name="btnFirmwareBrowser">
-            <property name="text">
-             <string>...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_8">
-            <property name="text">
-             <string>Configs folder</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1" colspan="2">
-           <widget class="QLineEdit" name="txtConfigsFolder">
-            <property name="maximumSize">
-             <size>
-              <width>1666666</width>
-              <height>16777215</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="3">
-           <widget class="QToolButton" name="btnConfigsBrowser">
-            <property name="text">
-             <string>...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Templates folder</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1" colspan="2">
+          <item row="7" column="1" colspan="2">
            <widget class="QLineEdit" name="txtTemplatesFolder">
             <property name="maximumSize">
              <size>
@@ -1128,27 +1070,75 @@ p, li { white-space: pre-wrap; }
             </property>
            </widget>
           </item>
-          <item row="5" column="3">
-           <widget class="QToolButton" name="btnTemplatesBrowser">
+          <item row="3" column="1" colspan="2">
+           <widget class="QLineEdit" name="txtLogFolder">
+            <property name="maximumSize">
+             <size>
+              <width>1666666</width>
+              <height>16777215</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Debug level</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="3">
+           <widget class="QToolButton" name="btnSnapshotsBrowser">
             <property name="text">
              <string>...</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
+          <item row="8" column="0">
            <widget class="QLabel" name="label_10">
             <property name="text">
              <string>Snapshots folder</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="1" colspan="2">
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Templates folder</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1" colspan="2">
+           <widget class="QLineEdit" name="txtFirmwareFolder">
+            <property name="maximumSize">
+             <size>
+              <width>1666666</width>
+              <height>16777215</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1" colspan="2">
            <widget class="QLineEdit" name="txtSnapshotsFolder"/>
           </item>
-          <item row="6" column="3">
-           <widget class="QToolButton" name="btnSnapshotsBrowser">
+          <item row="4" column="3">
+           <widget class="QToolButton" name="btnFirmwareBrowser">
             <property name="text">
              <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>Configs folder</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="txtConfigsFolder">
+            <property name="text">
+             <string/>
             </property>
            </widget>
           </item>

--- a/icepapcms/lib/configmanager.py
+++ b/icepapcms/lib/configmanager.py
@@ -39,7 +39,7 @@ class ConfigManager(Singleton):
     config_filename_override = None
     use_user_config = False
 
-    conf_path_list = ["/etc/icepapcms", "./configs", os.path.expanduser("~/.icepapcms/configs")]
+    conf_path_list = ["/etc/icepapcms", os.path.expanduser("~/.icepapcms/configs")]
     exe_folder = os.path.abspath(os.path.dirname(sys.argv[0]))
 
     username = 'NotValidated'
@@ -100,7 +100,7 @@ class ConfigManager(Singleton):
                 raise RuntimeError("Specified config file not found!")
         else:
             if self.use_user_config:
-                self.conf_path_list = [os.path.expanduser("~/.icepapcms/configs")]
+                self.conf_path_list = self.conf_path_list[1:]
             for loc in self.conf_path_list:
                 if os.path.exists(os.path.join(loc,"icepapcms.conf")):
                     self.configs_folder = loc

--- a/icepapcms/lib/configmanager.py
+++ b/icepapcms/lib/configmanager.py
@@ -13,7 +13,6 @@
 
 from .singleton import Singleton
 import os
-import sys
 from configobj import ConfigObj
 from validate import Validator
 import logging
@@ -40,7 +39,6 @@ class ConfigManager(Singleton):
     use_user_config = False
 
     conf_path_list = ["/etc/icepapcms", os.path.expanduser("~/.icepapcms/configs")]
-    exe_folder = os.path.abspath(os.path.dirname(sys.argv[0]))
 
     username = 'NotValidated'
 
@@ -66,8 +64,6 @@ class ConfigManager(Singleton):
     user_template=string(default='string with the configuration')
     [all_networks]
     use = boolean(default=False)
-    
-    
     '''
 
     defaults = defaults.splitlines()

--- a/icepapcms/lib/configmanager.py
+++ b/icepapcms/lib/configmanager.py
@@ -79,10 +79,8 @@ class ConfigManager(Singleton):
     @loggingInfo
     def init(self, *args):
         # Manage command line arguments and options
-        print("check args")
         if len(args):
             options = args[0]
-            print(options)
             if options.config_file:
                 self.config_filename_override = os.path.expanduser(options.config_file)
             if options.user_config:
@@ -97,16 +95,16 @@ class ConfigManager(Singleton):
                 self.config_filename = self.config_filename_override
                 self.configs_folder = self.config_filename_override
             else:
+                # If we specifically ask for a particular config file,
+                # then we don't want to start if it doesn't exist.
                 raise RuntimeError("Specified config file not found!")
         else:
             if self.use_user_config:
                 self.conf_path_list = [os.path.expanduser("~/.icepapcms/configs")]
             for loc in self.conf_path_list:
-                print("loc", loc)
                 if os.path.exists(os.path.join(loc,"icepapcms.conf")):
                     self.configs_folder = loc
                     self.config_filename = os.path.join(self.configs_folder, "icepapcms.conf")
-                    print("found:", self.config_filename, "in:", self.configs_folder)
                     break
         vdt = Validator()
         self.configspec = ConfigObj(self.defaults)
@@ -121,27 +119,21 @@ class ConfigManager(Singleton):
         # always create base folder if not found.
         # Using the recursive "makedirs" to create the full path.
         for folder in "log_folder", "snapshots_folder", "firmware_folder", "templates_folder":
-            print(self.config["icepap"][folder])
             directory = os.path.expanduser(self.config["icepap"][folder])
             if not os.path.exists(directory):
                 print("Create missing directory:", directory)
                 os.makedirs(directory)
+        
+        # If config filename is still None, default to the user home dir.
         if self.config_filename is None:
-            print("ggggg")
             self.configs_folder = os.path.expanduser("~/.icepapcms/configs")
             self.config_filename = os.path.join(self.configs_folder, "icepapcms.conf")
             if not os.path.exists(self.configs_folder):
                 os.makedirs(self.configs_folder)
+
+        # Update config obj with correct filename
         self.config.filename = self.config_filename
         self.config["icepap"]["configs_folder"] = self.configs_folder
-
-        print("base folder", self.base_folder)
-        #directory = os.path.join(self.base_folder, self.config["icepap"]["configs_folder"])
-        #self.config["icepap"]["configs_folder"] = directory
-        if os.access(self.config["icepap"]["configs_folder"], os.W_OK):
-            if not os.path.exists(self.config["icepap"]["configs_folder"]):
-                print("create conf folder")
-                os.makedirs(self.config["icepap"]["configs_folder"])
         
         print("Using config folder:", self.config["icepap"]["configs_folder"])
 

--- a/icepapcms/lib/configmanager.py
+++ b/icepapcms/lib/configmanager.py
@@ -28,21 +28,17 @@ class ConfigManager(Singleton):
     Postgres = "postgres"
     database = "database"
     icepap = "icepap"
-    folder = os.path.expanduser('~/.icepapcms/sqlitedb')
+    sqlite_folder = os.path.expanduser('~/.icepapcms/sqlitedb')
     log_folder = os.path.expanduser('~/.icepapcms/log')
     firmware_folder = os.path.expanduser('~/.icepapcms/firmware')
-    #configs_folder = os.path.expanduser('~/.icepapcms/configs')
-    templates_folder = os.path.expanduser('~/.icepapcms/templates')
-    #folder = "sqlitedb"
-    #log_folder = "log"
-    #firmware_folder = "firmware"
     configs_folder = ""
-    #templates_folder = "templates"
+    templates_folder = os.path.expanduser('~/.icepapcms/templates')
     snapshots_folder = os.path.expanduser('~/.icepapcms/snapshots')
     base_folder = os.path.expanduser('~/.icepapcms')
     config_filename = None
     config_filename_override = None
     use_user_config = False
+
     conf_path_list = ["/etc/icepapcms", "./configs", os.path.expanduser("~/.icepapcms/configs")]
     exe_folder = os.path.abspath(os.path.dirname(sys.argv[0]))
 
@@ -51,7 +47,7 @@ class ConfigManager(Singleton):
     defaults = '''
     [database]
     password = string(default=configure)
-    folder = string(default=''' + folder + ''')
+    folder = string(default=''' + sqlite_folder + ''')
     server = string(default=localhost:3306)
     user = string(default=icepapcms)
     database = string(default=sqlite)
@@ -126,8 +122,9 @@ class ConfigManager(Singleton):
         # Using the recursive "makedirs" to create the full path.
         for folder in "log_folder", "snapshots_folder", "firmware_folder", "templates_folder":
             print(self.config["icepap"][folder])
-            directory = self.config["icepap"][folder]
+            directory = os.path.expanduser(self.config["icepap"][folder])
             if not os.path.exists(directory):
+                print("Create missing directory:", directory)
                 os.makedirs(directory)
         if self.config_filename is None:
             print("ggggg")
@@ -135,6 +132,7 @@ class ConfigManager(Singleton):
             self.config_filename = os.path.join(self.configs_folder, "icepapcms.conf")
             if not os.path.exists(self.configs_folder):
                 os.makedirs(self.configs_folder)
+        self.config.filename = self.config_filename
         self.config["icepap"]["configs_folder"] = self.configs_folder
 
         print("base folder", self.base_folder)

--- a/icepapcms/lib/configmanager.py
+++ b/icepapcms/lib/configmanager.py
@@ -56,7 +56,6 @@ class ConfigManager(Singleton):
     debug_level = string(default=1)
     log_folder = string(default=''' + log_folder + ''')
     firmware_folder = string(default=''' + firmware_folder + ''')
-    configs_folder = string(default=''' + configs_folder + ''')
     templates_folder = string(default=''' + templates_folder + ''')
     snapshots_folder = string(default=''' + snapshots_folder + ''')
     [ldap]
@@ -131,9 +130,8 @@ class ConfigManager(Singleton):
 
         # Update config obj with correct filename
         self.config.filename = self.config_filename
-        self.config["icepap"]["configs_folder"] = self.configs_folder
         
-        print("Using config folder:", self.config["icepap"]["configs_folder"])
+        print("Using config folder:", self.configs_folder)
 
 
     @loggingInfo

--- a/icepapcms/lib/configmanager.py
+++ b/icepapcms/lib/configmanager.py
@@ -37,7 +37,10 @@ class ConfigManager(Singleton):
     config_filename_override = None
     use_user_config = False
 
-    conf_path_list = ["/etc/icepapcms", os.path.expanduser("~/.icepapcms/configs")]
+    if os.name == "nt":
+        conf_path_list = [os.path.expandvars("%systemdrive%/ProgramData/IcePAP"), os.path.expanduser("~/.icepapcms/configs")]
+    else:    
+        conf_path_list = ["/etc/icepap", os.path.expanduser("~/.icepapcms/configs")]
 
     username = 'NotValidated'
 

--- a/icepapcms/lib/configmanager.py
+++ b/icepapcms/lib/configmanager.py
@@ -33,7 +33,6 @@ class ConfigManager(Singleton):
     configs_folder = ""
     templates_folder = os.path.expanduser('~/.icepapcms/templates')
     snapshots_folder = os.path.expanduser('~/.icepapcms/snapshots')
-    base_folder = os.path.expanduser('~/.icepapcms')
     config_filename = None
     config_filename_override = None
     use_user_config = False
@@ -89,7 +88,7 @@ class ConfigManager(Singleton):
         if self.config_filename_override:
             if os.path.exists(self.config_filename_override):
                 self.config_filename = self.config_filename_override
-                self.configs_folder = self.config_filename_override
+                self.configs_folder = os.path.dirname(self.config_filename_override)
             else:
                 # If we specifically ask for a particular config file,
                 # then we don't want to start if it doesn't exist.

--- a/icepapcms/lib/configmanager.py
+++ b/icepapcms/lib/configmanager.py
@@ -38,7 +38,7 @@ class ConfigManager(Singleton):
     use_user_config = False
 
     if os.name == "nt":
-        conf_path_list = [os.path.expandvars("%systemdrive%/ProgramData/IcePAP"), os.path.expanduser("~/.icepapcms/configs")]
+        conf_path_list = [os.path.expandvars("%PROGRAMDATA%/IcePAP"), os.path.expanduser("~/.icepapcms/configs")]
     else:    
         conf_path_list = ["/etc/icepap", os.path.expanduser("~/.icepapcms/configs")]
 

--- a/icepapcms/lib/configmanager.py
+++ b/icepapcms/lib/configmanager.py
@@ -36,13 +36,14 @@ class ConfigManager(Singleton):
     #folder = "sqlitedb"
     #log_folder = "log"
     #firmware_folder = "firmware"
-    configs_folder = "configs"
+    configs_folder = ""
     #templates_folder = "templates"
     snapshots_folder = os.path.expanduser('~/.icepapcms/snapshots')
     base_folder = os.path.expanduser('~/.icepapcms')
     config_filename = None
     config_filename_override = None
-    conf_path_list = ["/etc/icepapcms", "./", os.path.expanduser("~/.icepapcms")]
+    use_user_config = False
+    conf_path_list = ["/etc/icepapcms", "./configs", os.path.expanduser("~/.icepapcms/configs")]
     exe_folder = os.path.abspath(os.path.dirname(sys.argv[0]))
 
     username = 'NotValidated'
@@ -86,8 +87,10 @@ class ConfigManager(Singleton):
         if len(args):
             options = args[0]
             print(options)
-            if options.config_path:
-                self.config_filename_override = os.path.expanduser(options.config_path)
+            if options.config_file:
+                self.config_filename_override = os.path.expanduser(options.config_file)
+            if options.user_config:
+                self.use_user_config = True
         self.configure()
 
     @loggingInfo
@@ -99,13 +102,16 @@ class ConfigManager(Singleton):
                 self.configs_folder = self.config_filename_override
             else:
                 raise RuntimeError("Specified config file not found!")
-        for loc in self.conf_path_list:
-            print("loc", loc)
-            if os.path.exists(os.path.join(loc,"configs/icepapcms.conf")):
-                self.configs_folder = loc + "/configs"
-                self.config_filename = os.path.join(self.configs_folder, "icepapcms.conf")
-                print("found:", self.config_filename, "in:", self.configs_folder)
-                break
+        else:
+            if self.use_user_config:
+                self.conf_path_list = [os.path.expanduser("~/.icepapcms/configs")]
+            for loc in self.conf_path_list:
+                print("loc", loc)
+                if os.path.exists(os.path.join(loc,"icepapcms.conf")):
+                    self.configs_folder = loc
+                    self.config_filename = os.path.join(self.configs_folder, "icepapcms.conf")
+                    print("found:", self.config_filename, "in:", self.configs_folder)
+                    break
         vdt = Validator()
         self.configspec = ConfigObj(self.defaults)
         self.config = ConfigObj(self.config_filename,

--- a/icepapcms/lib/stormmanager.py
+++ b/icepapcms/lib/stormmanager.py
@@ -48,8 +48,10 @@ class StormManager(Singleton):
             if self.db == self._config.Sqlite:
                 folder = self._config.config[self._config.database]["folder"]
                 loc = folder + '/icepapcms.db'
+                print("Using Sqlite database at %s" % loc)
                 create_db = not os.path.exists(loc)
                 if create_db:
+                    print("No database file found, creating it")
                     if not os.path.exists(folder):
                         os.mkdir(folder)
                 self._database = create_database("%s:%s" % (self.db, loc))
@@ -79,8 +81,8 @@ class StormManager(Singleton):
         try:
             sql_file = resource_filename('icepapcms.db',
                                          'creates_sqlite.sql')
-            with open(sql_file, 'rb') as f:
-                sql_script = f.read().decode()
+            with open(sql_file) as f:
+                sql_script = f.read()
             statements = re.compile(r";[ \t]*$", re.M)
 
             for statement in statements.split(sql_script):


### PR DESCRIPTION
At MAX-IV we deploy IcePAPCMS centrally, with separate icepap database configuration for each beamline. This makes sure that any settings are stored in the mysql database, and not by mistake spread out in the home folders of the different people doing the work. 
Earlier we have used a locally modified version of CMS, but we think this functionality would also benefit others.

Modifications in this PR
When starting, we first check if there is a config at /etc/icepapcms/icepapcms.cfg. If it's not there, then use the one in the user home directory.
Use the "--user" argument to force it to use the config from the home dir.
There is also the "--config-file" argument to specify a particular config file.