### PR TITLE
Fix raw_cfg_info referencing original dictionary

### DIFF
--- a/icepapcms/lib/icepapsmanager.py
+++ b/icepapcms/lib/icepapsmanager.py
@@ -157,7 +157,7 @@ class IcepapsManager(Singleton):
                 driver_version = driver_cfg.getParameter('VER', True)
                 if driver_version not in cfginfos_version_dict:
                     try:
-                        raw_cfg_info = CFG_INFOS_DEFAULTS[driver_version]
+                        raw_cfg_info = CFG_INFOS_DEFAULTS[driver_version].copy()
                     except KeyError:
                         raw_cfg_info = self._get_driver_raw_cfg_info(
                             icepap_name, addr)


### PR DESCRIPTION
raw_cfg_info is referencing original dictionary, hence, modifying raw_cfg_info also modifies the original dictionary. Copy the dictionary to avoid this.