### PR TITLE
Add missing setuptools dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         'configobj!=5.0.7',
         'ldap3',
         'PyYAML',
+        'setuptools',
 
     ],
     package_data={


### PR DESCRIPTION
icepapcms relies on pkg_resources which is provided by setuptools.

setuptools used to be a dependency for pip. That's not the case anymore for python >=3.13.